### PR TITLE
Fix the dependency generation

### DIFF
--- a/makemake.py
+++ b/makemake.py
@@ -90,7 +90,7 @@ def buildRequiresFromSpec( spec ):
 provides_to_rpm = {}
 for specname, spec in specs.iteritems():
     for package in spec.packages:
-        for provided in package.header['provides']:
+        for provided in (package.header['provides'] + [package.header['name']]):
             for rpmname in rpmNamesFromSpec( spec ):
                 provides_to_rpm[ provided ] = rpmname
 


### PR DESCRIPTION
I suspect maybe fedora's rpm python stuff puts the rpm name into
'provides' - CentOS's version doesn't seem to, so this commit
puts it in explicitly.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
