### PR TITLE
Add openstack-xapi-plugins RPM

### DIFF
--- a/SPECS/openstack-xapi-plugins.spec
+++ b/SPECS/openstack-xapi-plugins.spec
@@ -1,0 +1,35 @@
+Name:           openstack-xapi-plugins
+Version:        2013.1.2
+Release:        1
+Summary:        XenAPI plugins from OpenStack
+License:        ASL 2.0
+Group:          System/Hypervisor
+URL:            https://launchpad.net/nova/grizzly/%{version}/+download/nova-%{version}.tar.gz
+Source0:        nova-%{version}.tar.gz
+BuildArch:      noarch
+BuildRoot:      %{_tmppath}/nova-%{version}-%{release}
+
+%define debug_package %{nil}
+
+%description
+XenAPI plugins used by OpenStack to control XenServer.
+
+%prep
+%setup -q -n nova-%{version}
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_sysconfdir}
+cp -r plugins/xenserver/xenapi/etc/xapi.d %{buildroot}/%{_sysconfdir}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(755,root,root,-)
+%{_sysconfdir}/xapi.d/
+
+%changelog
+* Fri Jun 28 2013 Euan Harris <euan.harris@citrix.com>
+- Initial package
+

--- a/SPECS/xenserver.spec
+++ b/SPECS/xenserver.spec
@@ -11,6 +11,7 @@ Requires:       xenserver-install-wizard
 Requires:       xapi xapi-xe xe-create-templates xapi-python-devel
 Requires:       xenopsd-xc xenopsd-libvirt xenopsd-xenlight xenopsd-simulator
 Requires:       xenops-cli
+Requires:       openstack-xen-plugins
 Requires:       ffs xapi-libvirt-storage sm-cli
 Requires:       xcp-networkd
 Requires:       xcp-rrdd

--- a/sources.csv
+++ b/sources.csv
@@ -67,3 +67,4 @@ xcp-rrdd.spec,https://github.com/xen-org/xcp-rrdd/archive/0.9.0.tar.gz,xcp-rrdd-
 xenops.spec,https://github.com/xen-org/xenops/archive/0.9.0.tar.gz,ocaml-xenops-0.9.0.tar.gz
 xsiostat.spec,https://github.com/xenserver/xsiostat/archive/0.2.0.tar.gz,xsiostat-0.2.0.tar.gz
 eliloader.spec,https://github.com/djs55/xcp-eliloader/archive/master/0.3.tar.gz,eliloader-0.3.tar.gz
+openstack-xapi-plugins.spec,https://launchpad.net/nova/grizzly/2013.1.2/+download/nova-2013.1.2.tar.gz,nova-2013.1.2.tar.gz


### PR DESCRIPTION
OpenStack uses a few XAPI plugins to control XenServer.   There is a spec for building an RPM of these plugins, described here:

[https://github.com/openstack/nova/tree/master/plugins/xenserver/xenapi]

This spec differs slightly:
- The name is 'openstack-xapi-plugins', which is more accurate than 'openstack-xen-plugins'
- The release used is slightly newer
- The group is 'System/Hypervisor', which seems more appropriate than 'Applications/Utilities'
- The spec file is a bit shorter

Depending on how widespread the OpenStack RPM is, it may be more prudent to switch back to its name and group.
