### PR TITLE
build: Put RPMs in architecture-specific subdirectories

### DIFF
--- a/makemake.py
+++ b/makemake.py
@@ -77,10 +77,12 @@ for specname, spec in specs.iteritems():
     rpmnames = rpmNamesFromSpec( spec )
     srpmname = srpmNameFromSpec( spec )
     for r in rpmnames: 
-        print '%s: %s' % ( os.path.join( rpm_dir, r), 
-                           os.path.join( srpm_dir, srpmname ))
-        print '\tmock -r xenserver --resultdir="./RPMS/%(target_arch)s/" $<' 
-        print '\tcreaterepo --update RPMS/x86_64'
+        rpm_path = os.path.join( rpm_dir, r )
+        srpm_path = os.path.join( srpm_dir, srpmname )
+        rpm_outdir = os.path.dirname( rpm_path )
+        print '%s: %s' % ( rpm_path, srpm_path )
+        print '\tmock -r xenserver --resultdir="%s" $<' % rpm_outdir
+        print '\tcreaterepo --update %s' % rpm_dir
         
 # RPM build dependencies.   The 'requires' key for the *source* RPM is
 # actually the 'buildrequires' key from the spec

--- a/xapi.repo
+++ b/xapi.repo
@@ -1,6 +1,6 @@
 [xapi]
 name=CentOS-$releasever - xapi 
-baseurl=http://www.uk.xensource.com/~dscott/xapi/RPMS/$basearch/
+baseurl=http://www.uk.xensource.com/~dscott/xapi/RPMS/
 gpgcheck=0
 Priority=1
 enabled=1

--- a/xenserver.cfg.in
+++ b/xenserver.cfg.in
@@ -69,7 +69,7 @@ enabled=0
 
 [mock]
 name=Mock output
-baseurl=file://@HOME@/rpmbuild/RPMS/x86_64
+baseurl=file://@HOME@/rpmbuild/RPMS
 gpgcheck=0
 priority=1
 enabled=1


### PR DESCRIPTION
Until now we have been putting all the RPMs we build in RPMS/x86_64.   Now that we also build noarch RPMs, we should have a more appropriate directory structure.    noarch RPMs will go in `RPMS/noarch`, and architecture specific RPMs will go in `RPMS/$basearch`.

**N.B.:** After merging this change you will need to update `/etc/mock/xenserver.cfg` on your build machine and `/etc/yum/repos.d/xapi.repo` on any machines which are using this repository.
