### PR TITLE
Use built-in RPM dependency generator in all packages

### DIFF
--- a/SPECS/ocaml-camomile.spec
+++ b/SPECS/ocaml-camomile.spec
@@ -19,10 +19,6 @@ ExcludeArch:    ppc64 sparc64 s390 s390x
 
 BuildRequires:  ocaml, ocaml-findlib-devel, ocaml-ocamldoc, ocaml-camlp4-devel
 
-%define _use_internal_dependency_generator 0
-%define __find_requires /usr/lib/rpm/ocaml-find-requires.sh
-%define __find_provides /usr/lib/rpm/ocaml-find-provides.sh
-
 %description
 Camomile is a Unicode library for ocaml. Camomile provides Unicode
 character type, UTF-8, UTF-16, UTF-32 strings, conversion to/from

--- a/SPECS/ocaml-libvirt.spec
+++ b/SPECS/ocaml-libvirt.spec
@@ -38,10 +38,6 @@ BuildRequires:  libvirt-devel >= 0.2.1
 BuildRequires:  perl
 BuildRequires:  gawk
 
-%define _use_internal_dependency_generator 0
-%define __find_requires /usr/lib/rpm/ocaml-find-requires.sh
-%define __find_provides /usr/lib/rpm/ocaml-find-provides.sh
-
 %description
 OCaml binding for libvirt.
 

--- a/SPECS/ocaml-ounit.spec
+++ b/SPECS/ocaml-ounit.spec
@@ -18,8 +18,6 @@ BuildRequires:  ocaml-findlib-devel
 BuildRequires:  ocaml-camlp4 ocaml-camlp4-devel
 BuildRequires:  ocaml-ocamldoc
 
-%define _use_internal_dependency_generator 0
-
 
 %description
 OUnit is a unit test framework for OCaml. It allows one to easily

--- a/SPECS/ocaml-text.spec
+++ b/SPECS/ocaml-text.spec
@@ -18,10 +18,6 @@ BuildRequires:  ocaml-findlib-devel
 BuildRequires:  ocaml-camlp4
 BuildRequires:  ocaml-ocamldoc
 
-%define _use_internal_dependency_generator 0
-%define __find_requires /usr/lib/rpm/ocaml-find-requires.sh
-%define __find_provides /usr/lib/rpm/ocaml-find-provides.sh
-
 
 %description
 OCaml-Text is a library for dealing with ``text'', i.e. sequence of


### PR DESCRIPTION
ocaml-camomile.spec, ocaml-libvirt.spec, ocaml-ounit.spec and ocaml-text.spec turn off RPM's built in dependency generation:

> %define _use_internal_dependency_generator 0 
> %define __find_requires /usr/lib/rpm/ocaml-find-requires.sh
> %define __find_provides /usr/lib/rpm/ocaml-find-provides.sh 

This doesn't cause problems building in mock on Fedora, but does seem to cause dependency problems when building without it on CentOS.

The ocaml-find-requires.sh and ocaml-find-provides.sh scripts seem quite old and it looks like they are no longer needed with modern versions of RPM.   Is there any reason to use them in these four spec files?
