### PR TITLE
Remove the need to install xenserver.cfg in /etc/mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ su - <user>
 git clone git://github.com/xen-org/xen-api-rpm-buildroot.git /home/<user>/rpmbuild
 
 ./configure.sh
-sudo cp xenserver.cfg /etc/mock/
 
 ./makemake.py > Makefile
+
 make
 ```

--- a/configure.sh
+++ b/configure.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-sed "s|@HOME@|$HOME|" xenserver.cfg.in > xenserver.cfg
+mkdir mock
+sed "s|@HOME@|$HOME|" xenserver.cfg.in > mock/xenserver.cfg
+ln -s /etc/mock/default.cfg mock/
+ln -s /etc/mock/site-defaults.cfg mock/
+ln -s /etc/mock/logging.ini mock/

--- a/makemake.py
+++ b/makemake.py
@@ -139,7 +139,7 @@ for specname, spec in specs.iteritems():
         rpm_outdir = os.path.dirname( rpm_path )
         print '%s: %s' % ( rpm_path, srpm_path )
         print '\t@echo [MOCK] $@'
-        print '\t@mock --quiet -r xenserver --resultdir="%s" $<' % rpm_outdir
+        print '\t@mock --configdir=mock --quiet -r xenserver --resultdir="%s" $<' % rpm_outdir
         print '\t@echo [CREATEREPO] $@'
         print '\t@createrepo --quiet --update %s' % rpm_dir
         


### PR DESCRIPTION
Instead, put the config in rpmbuild/mock and symlink the other necessary files from /etc/mock.  This means that you don't have to be root to set up a build environment.
