### PR TITLE
build: Work around RPM library limitations in RPM 4.8 on CentOS 6.4

### DIFF
--- a/makemake.py
+++ b/makemake.py
@@ -78,13 +78,11 @@ def srpmNameFromSpec( spec ):
 # Rules to build SRPM from SPEC
 for specname, spec in specs.iteritems():
     srpmname = srpmNameFromSpec( spec )
-    sources = [ os.path.join( src_dir, p ) for p in spec.sourceHeader['source'] ]
-    patches = [ os.path.join( src_dir, p ) for p in spec.sourceHeader['patch'] ]
+    sources = [ os.path.join( src_dir, os.path.basename( p[0] ) ) for p in spec.sources ]
 
-    print '%s: %s %s %s' % (os.path.join( srpm_dir, srpmname ), 
+    print '%s: %s %s' % (os.path.join( srpm_dir, srpmname ), 
                          os.path.join( spec_dir, specname ),
-                         " ".join( sources ),
-                         " ".join( patches ) )
+                         " ".join( sources ) )
     print '\t@echo [RPMBUILD] $@' 
     print '\t@rpmbuild --quiet -bs $<'
 


### PR DESCRIPTION
CentOS 6.4 ships with RPM 4.8.   In this version, the sourceHeader
object doesn't seem to handle the 'sources' and 'patches' RPM tags.
Asking for spec.sourceHeader['sources'] always returns an empty list.
Work around this by using spec.sources, which contains the full paths
of sources and patches.

Signed-off-by: Euan Harris euan.harris@citrix.com
