### PR TITLE
build: Add short targets for RPMs

### DIFF
--- a/makemake.py
+++ b/makemake.py
@@ -173,8 +173,11 @@ all_srpms = [ os.path.join( srpm_dir, srpmNameFromSpec( s ) )
               for s in specs.values() ]
 
 all_rpms = []
-for rpms in [ rpmNamesFromSpec( s ) for s in specs.values() ]:
-    all_rpms += map( (lambda rpm: os.path.join( rpm_dir, rpm )), rpms )
+for spec in specs.values():
+    rpms = rpmNamesFromSpec( spec )
+    rpm_paths = map( (lambda rpm: os.path.join( rpm_dir, rpm )), rpms )
+    all_rpms += rpm_paths
+    print "%s: %s" % ( spec.sourceHeader['name'], " ".join( rpm_paths ) )
 
 
 print "rpms: " + " \\\n\t".join( all_rpms )


### PR DESCRIPTION
N.B. Short targets are based on the name directive in the spec file,
which may differ from the name of the spec file itself.

Signed-off-by: Euan Harris euan.harris@citrix.com
