### PR TITLE
build: Rename forkexec to forkexecd

### DIFF
--- a/SPECS/forkexecd.spec
+++ b/SPECS/forkexecd.spec
@@ -1,11 +1,11 @@
-Name:           forkexec
+Name:           forkexecd
 Version:        0.9.0
 Release:        1
 Summary:        A subprocess management service
 License:        LGPL
 Group:          Development/Other
 URL:            https://github.com/xen-org/forkexecd/archive/forkexecd-0.9.0.tar.gz
-Source0:        https://github.com/xen-org/forkexecd/archive/forkexecd-%{version}/forkexecd-%{version}.tar.gz
+Source0:        https://github.com/xen-org/%{name}/archive/%{name}-%{version}/%{name}-%{version}.tar.gz
 Source1:        forkexecd-init
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-findlib ocaml-camlp4-devel
@@ -19,7 +19,7 @@ A service which starts and manages subprocesses, avoiding the need to manually
 fork() and exec() in a multithreaded program.
 
 %prep
-%setup -q -n forkexecd-forkexecd-%{version}
+%setup -q -n %{name}-%{name}-%{version}
 
 %build
 ocaml setup.ml -configure --destdir %{buildroot}/%{_libdir}/ocaml

--- a/SPECS/ocaml-netdev.spec
+++ b/SPECS/ocaml-netdev.spec
@@ -7,8 +7,8 @@ Group:          Development/Other
 URL:            https://github.com/xen-org/netdev/archive/netdev-0.9.0.tar.gz
 Source0:        https://github.com/xen-org/netdev/archive/netdev-%{version}/netdev-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
-BuildRequires:  ocaml ocaml-findlib forkexec-devel ocaml-stdext-devel
-#required by forkexec
+BuildRequires:  ocaml ocaml-findlib forkexecd-devel ocaml-stdext-devel
+#required by forkexecd
 BuildRequires:  ocaml-syslog-devel
 Requires:       ocaml ocaml-findlib
 

--- a/SPECS/ocaml-tapctl.spec
+++ b/SPECS/ocaml-tapctl.spec
@@ -8,8 +8,8 @@ URL:            https://github.com/xen-org/tapctl/archive/tapctl-0.9.0.tar.gz
 Source0:        https://github.com/xen-org/tapctl/archive/tapctl-%{version}/tapctl-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-findlib ocaml-camlp4-devel
-BuildRequires:  forkexec-devel ocaml-stdext-devel ocaml-rpc-devel
-# required by forkexec
+BuildRequires:  forkexecd-devel ocaml-stdext-devel ocaml-rpc-devel
+# required by forkexecd
 BuildRequires:  ocaml-syslog-devel
 Requires:       ocaml ocaml-findlib
 

--- a/SPECS/ocaml-xen-api-libs-transitional.spec
+++ b/SPECS/ocaml-xen-api-libs-transitional.spec
@@ -7,7 +7,7 @@ Group:          Development/Other
 URL:            http://github.com/xen-org/xen-api-libs-transitional
 Source0:        https://github.com/xen-org/xen-api-libs-transitional/archive/xen-api-libs-transitional-%{version}/xen-api-libs-transitional-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
-BuildRequires:  ocaml ocaml-findlib ocaml-stdext-devel xmlm-devel forkexec-devel
+BuildRequires:  ocaml ocaml-findlib ocaml-stdext-devel xmlm-devel forkexecd-devel
 BuildRequires:  ocaml-rpc-devel ocaml-xen-lowlevel-libs-devel ocaml-xenstore-devel
 BuildRequires:  ocaml-xenstore-clients-devel xen-devel ocaml-camlp4-devel
 BuildRequires:  ocaml-syslog-devel

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -18,7 +18,7 @@ BuildRequires: ocaml ocaml-findlib ocaml-camlp4-devel ocaml-ocamldoc
 BuildRequires: pam-devel tetex-latex ocaml xen-devel zlib-devel
 BuildRequires: ocaml-xcp-idl-devel ocaml-xen-api-libs-transitional-devel
 BuildRequires: ocaml-xen-api-client-devel omake ocaml-netdev-devel
-BuildRequires: ocaml-cdrom-devel ocaml-fd-send-recv-devel forkexec-devel
+BuildRequires: ocaml-cdrom-devel ocaml-fd-send-recv-devel forkexecd-devel
 BuildRequires: ocaml-libvhd-devel ocaml-nbd-devel ocaml-oclock-devel
 BuildRequires: ocaml-ounit-devel ocaml-rpc-devel ocaml-ssl-devel ocaml-stdext-devel
 BuildRequires: ocaml-syslog-devel ocaml-tapctl-devel ocaml-xen-lowlevel-libs-devel

--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -12,7 +12,7 @@ Source3:        xcp-networkd-network-conf
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-obuild ocaml-findlib ocaml-camlp4-devel
 BuildRequires:  ocaml-xcp-idl-devel ocaml-syslog-devel ocaml-rpc-devel
-BuildRequires:  ocaml-stdext-devel forkexec-devel ocaml-xen-api-libs-transitional-devel
+BuildRequires:  ocaml-stdext-devel forkexecd-devel ocaml-xen-api-libs-transitional-devel
 BuildRequires:  ocaml-xcp-inventory-devel ocaml-ounit-devel
 BuildRequires:  ocaml-re-devel ocaml-cohttp-devel cmdliner-devel
 BuildRequires:  ocaml-xen-api-client-devel

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -16,7 +16,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-obuild ocaml-findlib ocaml-camlp4-devel
 BuildRequires:  ocaml-xcp-idl-devel ocaml-syslog-devel ocaml-rpc-devel
 BuildRequires:  ocaml-re-devel ocaml-cohttp-devel cmdliner-devel
-BuildRequires:  ocaml-oclock-devel ocaml-uuidm-devel forkexec-devel
+BuildRequires:  ocaml-oclock-devel ocaml-uuidm-devel forkexecd-devel
 BuildRequires:  ocaml-libvirt-devel libvirt-devel ocaml-qmp-devel
 BuildRequires:  ocaml-xen-lowlevel-libs-devel ocaml-sexplib
 BuildRequires:  ocaml-xenstore-clients-devel ocaml-xenstore-devel
@@ -40,7 +40,7 @@ Simple VM manager for Xen and KVM using libvirt.
 Summary:        %{name} using xc
 Group:          Development/Other
 Requires:       %{name} = %{version}-%{release}
-Requires:       xen-libs vncterm forkexec
+Requires:       xen-libs vncterm forkexecd
 
 %description    xc
 Simple VM manager for Xen using libxc.


### PR DESCRIPTION
This matches the package name to the repository name and
is the way we handle other daemons such as xenopsd.

Signed-off-by: Euan Harris euan.harris@citrix.com
