### PR TITLE
xapi: Set OCAMLRUNPARAM to enable backtraces

### DIFF
--- a/SOURCES/xen-api-init
+++ b/SOURCES/xen-api-init
@@ -37,6 +37,7 @@ start() {
 	umask 077
 
         echo -n $"Starting xapi: "
+        OCAMLRUNPARAM=b
         daemon --pidfile="$PIDFILE" $exec -pidfile "$PIDFILE" -daemon true $XAPI_OPTIONS
         RETVAL=$?
         echo


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
