### PR TITLE
configure: Initialize the repository in RPMS

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
+echo -n "Writing mock configuration..."
 mkdir -p mock
 sed "s|@PWD@|$PWD|" xenserver.cfg.in > mock/xenserver.cfg
 ln -fs /etc/mock/default.cfg mock/
 ln -fs /etc/mock/site-defaults.cfg mock/
 ln -fs /etc/mock/logging.ini mock/
+echo " done"
+
+echo -n "Initializing repository..."
+createrepo --quiet RPMS
+echo " done"
+


### PR DESCRIPTION
This is not needed on Fedora, but is needed on ancient CentOS.

Fixes #117

Signed-off-by: Euan Harris euan.harris@citrix.com
