### PR TITLE
build: Ensure all spec files have mandatory %files list

### DIFF
--- a/SPECS/cmdliner.spec
+++ b/SPECS/cmdliner.spec
@@ -42,6 +42,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README CHANGES

--- a/SPECS/deriving-ocsigen.spec
+++ b/SPECS/deriving-ocsigen.spec
@@ -37,6 +37,9 @@ make install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc COPYING README CHANGES

--- a/SPECS/js_of_ocaml.spec
+++ b/SPECS/js_of_ocaml.spec
@@ -40,6 +40,9 @@ make install BINDIR=%{buildroot}/%{_bindir}/
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README CHANGES

--- a/SPECS/ocaml-cdrom.spec
+++ b/SPECS/ocaml-cdrom.spec
@@ -41,6 +41,9 @@ make install DESTDIR=%{buildroot}/%{_libdir}/ocaml
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc ChangeLog README.md

--- a/SPECS/ocaml-cohttp.spec
+++ b/SPECS/ocaml-cohttp.spec
@@ -39,6 +39,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README.md CHANGES

--- a/SPECS/ocaml-cstruct.spec
+++ b/SPECS/ocaml-cstruct.spec
@@ -40,6 +40,9 @@ ocaml setup.ml -install DESTDIR=%{buildroot}
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md CHANGES

--- a/SPECS/ocaml-fd-send-recv.spec
+++ b/SPECS/ocaml-fd-send-recv.spec
@@ -40,6 +40,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md LICENSE

--- a/SPECS/ocaml-lambda-term.spec
+++ b/SPECS/ocaml-lambda-term.spec
@@ -42,6 +42,9 @@ rm -f %{buildroot}/%{_libdir}/ocaml/usr/local/bin/lambda-term-actions
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE CHANGES

--- a/SPECS/ocaml-libvhd.spec
+++ b/SPECS/ocaml-libvhd.spec
@@ -40,6 +40,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc ChangeLog README.md

--- a/SPECS/ocaml-lwt.spec
+++ b/SPECS/ocaml-lwt.spec
@@ -71,6 +71,8 @@ strip $OCAMLFIND_DESTDIR/stublibs/dll*.so
 %clean
 rm -rf $RPM_BUILD_ROOT
 
+%files
+# This space intentionally left blank
 
 %files devel
 %defattr(-,root,root,-)

--- a/SPECS/ocaml-nbd.spec
+++ b/SPECS/ocaml-nbd.spec
@@ -41,6 +41,9 @@ make install DESTDIR=%{buildroot}/%{_libdir}/ocaml
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc ChangeLog README.markdown

--- a/SPECS/ocaml-netdev.spec
+++ b/SPECS/ocaml-netdev.spec
@@ -42,6 +42,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README.md ChangeLog MAINTAINERS

--- a/SPECS/ocaml-oclock.spec
+++ b/SPECS/ocaml-oclock.spec
@@ -47,6 +47,9 @@ make install DESTDIR=%{buildroot}/%{_libdir}/ocaml
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README.markdown

--- a/SPECS/ocaml-ocplib-endian.spec
+++ b/SPECS/ocaml-ocplib-endian.spec
@@ -44,6 +44,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc COPYING.txt README.md

--- a/SPECS/ocaml-qmp.spec
+++ b/SPECS/ocaml-qmp.spec
@@ -40,6 +40,9 @@ make install DESTDIR=%{buildroot}/%{_libdir}/ocaml
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc ChangeLog README.md LICENSE

--- a/SPECS/ocaml-re.spec
+++ b/SPECS/ocaml-re.spec
@@ -37,6 +37,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README CHANGES

--- a/SPECS/ocaml-react.spec
+++ b/SPECS/ocaml-react.spec
@@ -59,6 +59,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root,-)
 %doc CHANGES README

--- a/SPECS/ocaml-rpc.spec
+++ b/SPECS/ocaml-rpc.spec
@@ -38,6 +38,9 @@ make install DESTDIR=${buildroot}
 %clean
 rm -rf %{buildroot}
 
+%files
+# This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md

--- a/SPECS/ocaml-ssl.spec
+++ b/SPECS/ocaml-ssl.spec
@@ -40,6 +40,9 @@ make install DESTDIR=%{buildroot}
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc CHANGES COPYING README

--- a/SPECS/ocaml-stdext.spec
+++ b/SPECS/ocaml-stdext.spec
@@ -39,6 +39,9 @@ make install DESTDIR=${buildroot}
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md

--- a/SPECS/ocaml-syslog.spec
+++ b/SPECS/ocaml-syslog.spec
@@ -36,6 +36,9 @@ make install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc Changelog

--- a/SPECS/ocaml-tapctl.spec
+++ b/SPECS/ocaml-tapctl.spec
@@ -42,6 +42,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README.md ChangeLog MAINTAINERS

--- a/SPECS/ocaml-text.spec
+++ b/SPECS/ocaml-text.spec
@@ -54,6 +54,9 @@ rm -rf $RPM_BUILD_ROOT/usr/local/share/doc
 rm -rf $RPM_BUILD_ROOT
 
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root,-)
 %doc /usr/share/doc/ocaml-text/*

--- a/SPECS/ocaml-uri.spec
+++ b/SPECS/ocaml-uri.spec
@@ -37,6 +37,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md CHANGES

--- a/SPECS/ocaml-uuidm.spec
+++ b/SPECS/ocaml-uuidm.spec
@@ -41,6 +41,9 @@ rm -f %{buildroot}/%{_libdir}/ocaml/usr/local/bin/uuidtrip
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README CHANGES

--- a/SPECS/ocaml-xcp-idl.spec
+++ b/SPECS/ocaml-xcp-idl.spec
@@ -52,6 +52,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README.md ChangeLog MAINTAINERS

--- a/SPECS/ocaml-xcp-rrd.spec
+++ b/SPECS/ocaml-xcp-rrd.spec
@@ -37,6 +37,9 @@ make install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README.md ChangeLog MAINTAINERS

--- a/SPECS/ocaml-xen-api-client.spec
+++ b/SPECS/ocaml-xen-api-client.spec
@@ -42,6 +42,9 @@ OCAMLFIND_DESTDIR=%{buildroot}/%{_libdir}/ocaml ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md CHANGES

--- a/SPECS/ocaml-xen-api-libs-transitional.spec
+++ b/SPECS/ocaml-xen-api-libs-transitional.spec
@@ -44,6 +44,9 @@ make install DESTDIR=%{buildroot}/%{_libdir}/ocaml
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc ChangeLog README.md LICENSE

--- a/SPECS/ocaml-xen-lowlevel-libs.spec
+++ b/SPECS/ocaml-xen-lowlevel-libs.spec
@@ -40,6 +40,9 @@ make install DESTDIR=${buildroot}
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md

--- a/SPECS/ocaml-xenops.spec
+++ b/SPECS/ocaml-xenops.spec
@@ -40,6 +40,9 @@ make install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE README.md ChangeLog MAINTAINERS

--- a/SPECS/ocaml-xenstore-clients.spec
+++ b/SPECS/ocaml-xenstore-clients.spec
@@ -39,6 +39,9 @@ make install DESTDIR=${buildroot}
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md LICENSE MAINTAINERS

--- a/SPECS/ocaml-xenstore.spec
+++ b/SPECS/ocaml-xenstore.spec
@@ -37,6 +37,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README CHANGES LICENSE

--- a/SPECS/ocaml-yojson.spec
+++ b/SPECS/ocaml-yojson.spec
@@ -37,6 +37,9 @@ make install DESTDIR=%{buildroot} BINDIR=%{buildroot}/%{_bindir}
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README.md LICENSE

--- a/SPECS/ocaml-zed.spec
+++ b/SPECS/ocaml-zed.spec
@@ -39,6 +39,9 @@ ocaml setup.ml -install
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc LICENSE CHANGES

--- a/SPECS/xmlm.spec
+++ b/SPECS/xmlm.spec
@@ -44,6 +44,9 @@ rm -f %{buildroot}/%{_libdir}/ocaml/usr/local/bin/xmltrip
 %clean
 rm -rf %{buildroot}
 
+%files
+#This space intentionally left blank
+
 %files devel
 %defattr(-,root,root)
 %doc README CHANGES


### PR DESCRIPTION
A spec file must have a %files list, even if the list is empty.  Some of
our base packages don't have %files lists, which causes mock to build
them and throw them away.   We still generate Makefile rules to build
these files, so they are rebuilt and thrown away every time we run make.

For library packages, we should move the libraries into the base package;
keep only the headers, interfaces or other developer-focussed files
in the -devel package, and have the -devel package depend on the base
package.

Even with this change there is still some overbuilding, which seems to be
caused by the libvirt-daemon-driver-uml, libvirt-daemon-qemu and libvirt-daemon-uml
targets in the makefile.  We generate make targets for these, but we don't 
build (or at least keep) the packages - presumably they are not built because
of conditionals in the spec file.   It's annoying that rpmlib seems to be giving us
the impression that these are real packages that will be built - I thought it was 
correctly handling all the conditional definitions.
