### PR TITLE
xapi-libvirt-storage: Remove redundant renaming in %setup rule

### DIFF
--- a/SPECS/xapi-libvirt-storage.spec
+++ b/SPECS/xapi-libvirt-storage.spec
@@ -17,7 +17,7 @@ BuildRequires:  ocaml-oclock-devel
 Allows the manipulation of libvirt storage pools and volumes via xapi.
 
 %prep
-%setup -q -n %{name}-%{version}
+%setup -q
 
 %build
 make


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
