### PR TITLE
ocplib-endian 0.4's META file doesn't trash the toplevel

### DIFF
--- a/SPECS/ocaml-ocplib-endian.spec
+++ b/SPECS/ocaml-ocplib-endian.spec
@@ -1,5 +1,5 @@
 Name:           ocaml-ocplib-endian
-Version:        0.3
+Version:        0.4
 Release:        0
 Summary:        Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01.
 License:        LGPL


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@eu.citrix.com
