### PR TITLE
specs: Package release tags should start at 1

### DIFF
--- a/SPECS/biniou.spec
+++ b/SPECS/biniou.spec
@@ -1,6 +1,6 @@
 Name:           biniou
 Version:        1.0.6
-Release:        0
+Release:        1
 Summary:        Binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/cmdliner.spec
+++ b/SPECS/cmdliner.spec
@@ -1,6 +1,6 @@
 Name:           cmdliner
 Version:        0.9.3
-Release:        0
+Release:        1
 Summary:        Declarative definition of commandline interfaces for OCaml
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/cppo.spec
+++ b/SPECS/cppo.spec
@@ -1,6 +1,6 @@
 Name:           cppo
 Version:        0.9.3
-Release:        0
+Release:        1
 Summary:        Equivalent of the C preprocessor for OCaml
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/deriving-ocsigen.spec
+++ b/SPECS/deriving-ocsigen.spec
@@ -1,6 +1,6 @@
 Name:           deriving-ocsigen
 Version:        0.3c
-Release:        0
+Release:        1
 Summary:        Extension to OCaml for deriving functions from type declarations
 License:        MIT
 Group:          Development/Other

--- a/SPECS/easy-format.spec
+++ b/SPECS/easy-format.spec
@@ -1,6 +1,6 @@
 Name:           easy-format
 Version:        1.0.1
-Release:        0
+Release:        1
 Summary:        Indentation made easy
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/eliloader.spec
+++ b/SPECS/eliloader.spec
@@ -1,7 +1,7 @@
 Summary: Bootloader for EL-based distros that support Xen
 Name: eliloader
 Version: 0.3
-Release: 0
+Release: 1
 Source0: https://github.com/djs55/xcp-%{name}/archive/master/%{version}/%{name}-%{version}.tar.gz
 License: GPL
 Group: Applications/System

--- a/SPECS/ffs.spec
+++ b/SPECS/ffs.spec
@@ -1,6 +1,6 @@
 Name:           ffs
 Version:        0.9.16
-Release:        0
+Release:        1
 Summary:        Simple flat file storage manager for the xapi toolstack
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/message-switch.spec
+++ b/SPECS/message-switch.spec
@@ -1,6 +1,6 @@
 Name:           message-switch
 Version:        0.10.0
-Release:        0
+Release:        1
 Summary:        A store and forward message switch
 License:        FreeBSD
 Group:          Development/Other

--- a/SPECS/ocaml-cohttp.spec
+++ b/SPECS/ocaml-cohttp.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-cohttp
 Version:        0.9.8
-Release:        0
+Release:        1
 Summary:        An HTTP library for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-libvhd.spec
+++ b/SPECS/ocaml-libvhd.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-libvhd
 Version:        0.9.1
-Release:        0
+Release:        1
 Summary:        vhd manipulation via libvhd
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/ocaml-lwt.spec
+++ b/SPECS/ocaml-lwt.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-lwt
 Version:        2.4.3
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        OCaml lightweight thread library
 
 Group:          Development/Libraries

--- a/SPECS/ocaml-nbd.spec
+++ b/SPECS/ocaml-nbd.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-nbd
 Version:        0.9.0
-Release:        0
+Release:        1
 Summary:        Pure OCaml implementation of the Network Block Device protocol
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/SPECS/ocaml-obuild.spec
+++ b/SPECS/ocaml-obuild.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-obuild
 Version:        0.0.2
-Release:        0
+Release:        1
 Summary:        Simple build tool for OCaml programs
 License:        BSD2
 Group:          Development/Other

--- a/SPECS/ocaml-ocplib-endian.spec
+++ b/SPECS/ocaml-ocplib-endian.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-ocplib-endian
 Version:        0.4
-Release:        0
+Release:        1
 Summary:        Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01.
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-qmp.spec
+++ b/SPECS/ocaml-qmp.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-qmp
 Version:        0.9.1
-Release:        0
+Release:        1
 Summary:        Pure OCaml implementation of the Qemu Message Protocol (QMP)
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/SPECS/ocaml-re.spec
+++ b/SPECS/ocaml-re.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-re
 Version:        1.2.1
-Release:        0
+Release:        1
 Summary:        A regular expression library for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-react.spec
+++ b/SPECS/ocaml-react.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-react
 Version:        0.9.4
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        OCaml framework for Functional Reactive Programming (FRP)
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)

--- a/SPECS/ocaml-rpc.spec
+++ b/SPECS/ocaml-rpc.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-rpc
 Version:        1.4.1
-Release:        0
+Release:        1
 Summary:        An RPC library for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-sexplib.spec
+++ b/SPECS/ocaml-sexplib.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-sexplib
 Version:        109.20.00
-Release:        0
+Release:        1
 Summary:        Convert values to and from s-expressions in OCaml
 
 Group:          Development/Other

--- a/SPECS/ocaml-syslog.spec
+++ b/SPECS/ocaml-syslog.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-syslog
 Version:        1.4
-Release:        0
+Release:        1
 Summary:        Syslog bindings for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-tapctl.spec
+++ b/SPECS/ocaml-tapctl.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-tapctl
 Version:        0.9.0
-Release:        0
+Release:        1
 Summary:        Manipulate running tapdisk instances
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-text.spec
+++ b/SPECS/ocaml-text.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-text
 Version:        0.6
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        OCaml-Text is a library for dealing with ``text'', i.e. sequence of unicode characters, in a convenient way.
 
 Group:          Development/Libraries

--- a/SPECS/ocaml-type-conv.spec
+++ b/SPECS/ocaml-type-conv.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-type-conv
 Version:        109.20.00
-Release:        0
+Release:        1
 Summary:        OCaml base library for type conversion
 
 Group:          Development/Other

--- a/SPECS/ocaml-uri.spec
+++ b/SPECS/ocaml-uri.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-uri
 Version:        1.3.8
-Release:        0
+Release:        1
 Summary:        A URI library for OCaml
 License:        ISC
 Group:          Development/Other

--- a/SPECS/ocaml-uuidm.spec
+++ b/SPECS/ocaml-uuidm.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-uuidm
 Version:        0.9.5
-Release:        0
+Release:        1
 Summary:        Universally Unique IDentifiers (UUIDs) for OCaml
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/ocaml-xcp-idl.spec
+++ b/SPECS/ocaml-xcp-idl.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xcp-idl
 Version:        0.9.11
-Release:        0
+Release:        1
 Summary:        Common interface definitions for XCP services
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-xcp-rrd.spec
+++ b/SPECS/ocaml-xcp-rrd.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xcp-rrd
 Version:        0.9.0
-Release:        0
+Release:        1
 Summary:        Round-Robin Datasources in OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-xen-api-client.spec
+++ b/SPECS/ocaml-xen-api-client.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xen-api-client
 Version:        0.9.4
-Release:        0
+Release:        1
 Summary:        XenServer XenAPI Client Library for OCaml
 License:        LGPLv2
 Group:          Development/Libraries

--- a/SPECS/ocaml-xen-lowlevel-libs.spec
+++ b/SPECS/ocaml-xen-lowlevel-libs.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xen-lowlevel-libs
 Version:        0.9.5
-Release:        0
+Release:        1
 Summary:        Xen hypercall bindings for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-xenops.spec
+++ b/SPECS/ocaml-xenops.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xenops
 Version:        0.9.0
-Release:        0
+Release:        1
 Summary:        Low-level xen control operations OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-xenstore-clients.spec
+++ b/SPECS/ocaml-xenstore-clients.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xenstore-clients
 Version:        0.9.0
-Release:        0
+Release:        1
 Summary:        Unix xenstore clients for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-xenstore.spec
+++ b/SPECS/ocaml-xenstore.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xenstore
 Version:        1.2.1
-Release:        0
+Release:        1
 Summary:        Xenstore protocol implementation in OCaml
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/ocaml-yojson.spec
+++ b/SPECS/ocaml-yojson.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-yojson
 Version:        1.1.6
-Release:        0
+Release:        1
 Summary:        A JSON parser and priter for OCaml
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/ocaml-zed.spec
+++ b/SPECS/ocaml-zed.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-zed
 Version:        1.2
-Release:        0
+Release:        1
 Summary:        An abstract engine for text editing for OCaml
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/omake.spec
+++ b/SPECS/omake.spec
@@ -1,5 +1,5 @@
 Version: 0.9.8.6
-Release: 0
+Release: 1
 Summary: The omake build system.
 Name: omake
 URL: http://omake.metaprl.org/

--- a/SPECS/optcomp.spec
+++ b/SPECS/optcomp.spec
@@ -1,6 +1,6 @@
 Name:           optcomp
 Version:        1.4
-Release:        0
+Release:        1
 Summary:        Optional compilation with cpp-like directives
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/sm-cli.spec
+++ b/SPECS/sm-cli.spec
@@ -1,6 +1,6 @@
 Name:           sm-cli
 Version:        0.9.3
-Release:        0
+Release:        1
 Summary:        CLI for xapi toolstack storage managers.
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/utop.spec
+++ b/SPECS/utop.spec
@@ -1,6 +1,6 @@
 Name:           utop
 Version:        1.5
-Release:        0
+Release:        1
 Summary:        utop is a toplevel for OCaml which can run in a terminal or in emacs. It supports completion, colors, parenthesis matching, ...
 License:        BSD
 Group:          Development/Other

--- a/SPECS/xapi-libvirt-storage.spec
+++ b/SPECS/xapi-libvirt-storage.spec
@@ -1,6 +1,6 @@
 Name:           xapi-libvirt-storage
 Version:        0.9.6
-Release:        0
+Release:        1
 Summary:        Allows the manipulation of libvirt storage pools and volumes via xapi
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -3,7 +3,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 1.9.19
-Release: 0
+Release: 1
 Group:   System/Hypervisor
 License: LGPL+linking exception
 URL:  http://www.xen.org

--- a/SPECS/xe-create-templates.spec
+++ b/SPECS/xe-create-templates.spec
@@ -1,6 +1,6 @@
 Name:           xe-create-templates
 Version:        0.9.1
-Release:        0
+Release:        1
 Summary:        Creates default XenServer templates
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -1,6 +1,6 @@
 Name:           xenopsd
 Version:        0.9.21
-Release:        0
+Release:        1
 Summary:        Simple VM manager
 License:        LGPL
 Group:          Development/Other

--- a/SPECS/xenserver-install-wizard.spec
+++ b/SPECS/xenserver-install-wizard.spec
@@ -3,7 +3,7 @@
 Summary: a simple wizard to configure a XenServer
 Name:    xenserver-install-wizard
 Version: 0.2.17
-Release: 0
+Release: 1
 Group:   System/Hypervisor
 License: LGPL+linking exception
 URL:  http://github.com/djs55/xenserver-install-wizard

--- a/SPECS/xmlm.spec
+++ b/SPECS/xmlm.spec
@@ -1,6 +1,6 @@
 Name:           xmlm
 Version:        1.1.1
-Release:        0
+Release:        1
 Summary:        Streaming XML input/output for OCaml
 License:        BSD3
 Group:          Development/Other

--- a/SPECS/xsiostat.spec
+++ b/SPECS/xsiostat.spec
@@ -1,6 +1,6 @@
 Name:           xsiostat
 Version:        0.2.0
-Release:        0
+Release:        1
 Summary:        XenServer IO stat thingy
 License:        LGPL
 Group:          Development/Other


### PR DESCRIPTION
The RPM packaging guidelines say that the 'Release' tag starts
at 1 and is incremented whenever the package is changed but the
packaged version of the software remains the same.

Signed-off-by: Euan Harris euan.harris@citrix.com
