### PR TITLE
ocaml-qmp: Fix release numbers in changelog

### DIFF
--- a/SPECS/ocaml-qmp.spec
+++ b/SPECS/ocaml-qmp.spec
@@ -50,11 +50,11 @@ rm -rf %{buildroot}
 %{_libdir}/ocaml/qmp/*
 
 %changelog
-* Fri Aug 09 2013 Euan Harris <euan.harris@citrix.com> - 0.9.1-0
+* Fri Aug 09 2013 Euan Harris <euan.harris@citrix.com> - 0.9.1-1
 - Change representation of message timestamps from a tuple of ints to
   a float.  This avoids problems on 32-bit architectures and  follows
   the example of the OCaml standard library.
 
-* Wed May 29 2013 David Scott <dave.scott@eu.citrix.com> - 0.9.0-0
+* Wed May 29 2013 David Scott <dave.scott@eu.citrix.com> - 0.9.0-1
 - Initial package
 


### PR DESCRIPTION
Release numbers start at 1.

This isn't just being picky.   A Debian package's version number is the version number on the most recent changelog entry, so if the changelog is not correct the package doesn't get the right version number.

Having the version number in the changelog entry in this way isn't a mandatory part of the RPM spec, but it seems to be what's done with all the current Fedora packages.   For cases where no version is available, the Debian package builder script uses the version number field in the spec file.
