### PR TITLE
build: Copy extra sources to build directory during %prep

### DIFF
--- a/SPECS/ffs.spec
+++ b/SPECS/ffs.spec
@@ -19,6 +19,7 @@ Simple flat file storage manager for the xapi toolstack.
 
 %prep
 %setup -q
+cp %{SOURCE1} ffs-init
 
 %build
 make
@@ -28,7 +29,7 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_sbindir}
 install dist/build/ffs/ffs %{buildroot}/%{_sbindir}/ffs
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -m 0755 %{_sourcedir}/ffs-init %{buildroot}%{_sysconfdir}/init.d/ffs
+install -m 0755 ffs-init %{buildroot}%{_sysconfdir}/init.d/ffs
 
 %clean
 rm -rf %{buildroot}

--- a/SPECS/squeezed.spec
+++ b/SPECS/squeezed.spec
@@ -21,6 +21,7 @@ Memory ballooning daemon for the xapi toolstack.
 
 %prep
 %setup -q -n %{name}-%{name}-%{version}
+cp %{SOURCE1} squeezed-init
 
 %build
 make
@@ -30,7 +31,7 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_sbindir}
 install dist/build/squeezed/squeezed %{buildroot}/%{_sbindir}/squeezed
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -m 0755 %{_sourcedir}/squeezed-init %{buildroot}%{_sysconfdir}/init.d/squeezed
+install -m 0755 squeezed-init %{buildroot}%{_sysconfdir}/init.d/squeezed
 
 %clean
 rm -rf %{buildroot}

--- a/SPECS/xapi-libvirt-storage.spec
+++ b/SPECS/xapi-libvirt-storage.spec
@@ -18,6 +18,7 @@ Allows the manipulation of libvirt storage pools and volumes via xapi.
 
 %prep
 %setup -q
+cp %{SOURCE1} xapi-libvirt-storage-init
 
 %build
 make
@@ -27,7 +28,7 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_sbindir}
 install dist/build/sm-libvirt/sm-libvirt %{buildroot}/%{_sbindir}/xapi-libvirt-storage
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -m 0755 %{_sourcedir}/xapi-libvirt-storage-init %{buildroot}%{_sysconfdir}/init.d/xapi-libvirt-storage
+install -m 0755 xapi-libvirt-storage-init %{buildroot}%{_sysconfdir}/init.d/xapi-libvirt-storage
 
 %clean
 rm -rf %{buildroot}

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -51,6 +51,12 @@ Libraries for writing XenAPI clients in python.
 %prep 
 %setup -q -n xen-api-%{version}
 #%patch0 -p0 -b xapi-version.patch
+cp %{SOURCE1} xen-api-xapi-conf
+cp %{SOURCE2} xen-api-init
+cp %{SOURCE3} xen-api-xapissl
+cp %{SOURCE4} xen-api-db-conf
+cp %{SOURCE5} xen-api-pam
+
 
 %build
 ./configure --bindir=%{_bindir} --etcdir=/etc --libexecdir=%{_libexecdir}/xapi --xapiconf=/etc/xapi.conf --hooksdir=/etc/xapi/hook-scripts --sharedir=/usr/share/xapi --plugindir=/usr/lib/xapi/plugins
@@ -68,16 +74,16 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_sbindir}
 install -m 0755 ocaml/xapi/xapi.opt %{buildroot}/%{_sbindir}/xapi
 mkdir -p %{buildroot}/etc/pam.d
-install -m 0644 %{_sourcedir}/xen-api-pam %{buildroot}/etc/pam.d/xapi
+install -m 0644 xen-api-pam %{buildroot}/etc/pam.d/xapi
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -m 0755 %{_sourcedir}/xen-api-init %{buildroot}%{_sysconfdir}/init.d/xapi
+install -m 0755 xen-api-init %{buildroot}%{_sysconfdir}/init.d/xapi
 mkdir -p %{buildroot}/%{_libexecdir}/xapi
-install -m 0755 %{_sourcedir}/xen-api-xapissl %{buildroot}/%{_libexecdir}/xapi/xapissl
+install -m 0755 xen-api-xapissl %{buildroot}/%{_libexecdir}/xapi/xapissl
 install -m 0755 scripts/pci-info %{buildroot}/%{_libexecdir}/xapi/pci-info
 install -m 0755 scripts/update-mh-info %{buildroot}/%{_libexecdir}/xapi/update-mh-info
 mkdir -p %{buildroot}/etc/xapi
-install -m 0644 %{_sourcedir}/xen-api-xapi-conf %{buildroot}/etc/xapi.conf
-install -m 0644 %{_sourcedir}/xen-api-db-conf %{buildroot}/etc/xapi/db.conf
+install -m 0644 xen-api-xapi-conf %{buildroot}/etc/xapi.conf
+install -m 0644 xen-api-db-conf %{buildroot}/etc/xapi/db.conf
 
 mkdir -p %{buildroot}/%{_bindir}
 install -m 0755 ocaml/xe-cli/xe.opt %{buildroot}/%{_bindir}/xe

--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -23,6 +23,9 @@ Simple host networking management service for the xapi toolstack.
 
 %prep
 %setup -q -n %{name}-%{name}-%{version}
+cp %{SOURCE1} xcp-networkd-init
+cp %{SOURCE2} xcp-networkd-conf
+cp %{SOURCE3} xcp-networkd-network-conf
 
 %build
 make
@@ -32,10 +35,10 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_sbindir}
 install dist/build/xcp-networkd/xcp-networkd %{buildroot}/%{_sbindir}/xcp-networkd
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -m 0755 %{_sourcedir}/xcp-networkd-init %{buildroot}%{_sysconfdir}/init.d/xcp-networkd
+install -m 0755 xcp-networkd-init %{buildroot}%{_sysconfdir}/init.d/xcp-networkd
 mkdir -p %{buildroot}/etc/xcp
-install -m 0644 %{_sourcedir}/xcp-networkd-network-conf %{buildroot}/etc/xcp/network.conf
-install -m 0644 %{_sourcedir}/xcp-networkd-conf %{buildroot}/etc/xcp-networkd.conf
+install -m 0644 xcp-networkd-network-conf %{buildroot}/etc/xcp/network.conf
+install -m 0644 xcp-networkd-conf %{buildroot}/etc/xcp-networkd.conf
 
 %clean
 rm -rf %{buildroot}

--- a/SPECS/xcp-rrdd.spec
+++ b/SPECS/xcp-rrdd.spec
@@ -21,6 +21,7 @@ Statistics gathering daemon for the xapi toolstack.
 
 %prep
 %setup -q
+cp %{SOURCE1} xcp-rrdd-init
 
 %build
 make
@@ -30,7 +31,7 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_sbindir}
 make install DESTDIR=%{buildroot} SBINDIR=%{_sbindir}
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
-install -m 0755 %{_sourcedir}/xcp-rrdd-init %{buildroot}%{_sysconfdir}/init.d/xcp-rrdd
+install -m 0755 xcp-rrdd-init %{buildroot}%{_sysconfdir}/init.d/xcp-rrdd
 
 %clean
 rm -rf %{buildroot}

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -63,6 +63,12 @@ Simple VM manager for Xen using libxenlight
 
 %prep
 %setup -q
+cp %{SOURCE1} xenopsd-xc-init
+cp %{SOURCE2} xenopsd-simulator-init
+cp %{SOURCE3} xenopsd-libvirt-init
+cp %{SOURCE4} xenopsd-xenlight-init
+cp %{SOURCE5} xenopsd-conf
+cp %{SOURCE6} xenopsd-network-conf
 
 %build
 make
@@ -87,12 +93,12 @@ install -D scripts/network.conf %{buildroot}/%{_libexecdir}/%{name}/network.conf
 
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
 #install -m 0755 %{_sourcedir}/xenopsd-libvirt-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-libvirt
-install -m 0755 %{_sourcedir}/xenopsd-xc-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-xc
-install -m 0755 %{_sourcedir}/xenopsd-simulator-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-simulator
-install -m 0755 %{_sourcedir}/xenopsd-xenlight-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-xenlight
+install -m 0755 xenopsd-xc-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-xc
+install -m 0755 xenopsd-simulator-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-simulator
+install -m 0755 xenopsd-xenlight-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-xenlight
 mkdir -p %{buildroot}/etc/xapi
-install -m 0644 %{_sourcedir}/xenopsd-conf %{buildroot}/etc/xenopsd.conf
-install -m 0644 %{_sourcedir}/xenopsd-network-conf %{buildroot}/etc/xapi/network.conf
+install -m 0644 xenopsd-conf %{buildroot}/etc/xenopsd.conf
+install -m 0644 xenopsd-network-conf %{buildroot}/etc/xapi/network.conf
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
The Debian package builder makes a tarball from the build directory
after executing the %prep stage, so we must copy all extra sources
into the build directory during this stage.

Signed-off-by: Euan Harris euan.harris@citrix.com
