### PR TITLE
xen-api-init: OCAMLRUNPARAM needs to be exported

### DIFF
--- a/SOURCES/xen-api-init
+++ b/SOURCES/xen-api-init
@@ -37,7 +37,7 @@ start() {
 	umask 077
 
         echo -n $"Starting xapi: "
-        OCAMLRUNPARAM=b
+        export OCAMLRUNPARAM=b
         daemon --pidfile="$PIDFILE" $exec -pidfile "$PIDFILE" -daemon true $XAPI_OPTIONS
         RETVAL=$?
         echo


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
