### PR TITLE
ocaml-xenstore: Mark as conflicting with upstream xen-ocaml package

### DIFF
--- a/SPECS/ocaml-xenstore.spec
+++ b/SPECS/ocaml-xenstore.spec
@@ -9,6 +9,7 @@ Source0:        https://github.com/mirage/%{name}/archive/%{name}-%{version}/%{n
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-findlib ocaml-cstruct-devel ocaml-lwt-devel ocaml-camlp4-devel
 Requires:       ocaml ocaml-findlib
+Conflicts:      xen-ocaml
 
 %description
 An implementation of the xenstore protocol in OCaml.
@@ -16,6 +17,7 @@ An implementation of the xenstore protocol in OCaml.
 %package        devel
 Summary:        Development files for %{name}
 Group:          Development/Other
+Conflicts:      xen-ocaml-devel
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for


### PR DESCRIPTION
For now, at least, we need to use our own build of xenstore, not
the version provided by upstream.

See: http://lists.xen.org/archives/html/xen-api/2013-08/msg00069.html

Reported-by: Sayid Munawar
Signed-off-by: Euan Harris euan.harris@citrix.com
