### PR TITLE
Fixing typo in ffs.spec

### DIFF
--- a/SPECS/ffs.spec
+++ b/SPECS/ffs.spec
@@ -13,7 +13,7 @@ BuildRequires:  ocaml-xcp-idl-devel ocaml-syslog-devel ocaml-rpc-devel
 BuildRequires:  ocaml-re-devel ocaml-cohttp-devel cmdliner-devel
 BuildRequires:  ocaml-oclock-devel ocaml-libvhd-devel xen-devel libuuid-devel
 BuildRequires:  ocaml-tapctl-devel
-Requries:       nfs-utils
+Requires:       nfs-utils
 
 %description
 Simple flat file storage manager for the xapi toolstack.


### PR DESCRIPTION
Found a typo on Requires
