### PR TITLE
xapi: Add installation dependency on hwdata

### DIFF
--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -24,7 +24,7 @@ BuildRequires: ocaml-ounit-devel ocaml-rpc-devel ocaml-ssl-devel ocaml-stdext-de
 BuildRequires: ocaml-syslog-devel ocaml-tapctl-devel ocaml-xen-lowlevel-libs-devel
 BuildRequires: ocaml-xenstore-devel git cmdliner-devel ocaml-xcp-inventory-devel
 BuildRequires: ocaml-bitstring-devel libuuid-devel make utop
-Requires: stunnel ocaml-xcp-inventory
+Requires: stunnel ocaml-xcp-inventory hwdata
 
 %description
 XCP toolstack.


### PR DESCRIPTION
pci-info requires the pci.ids file, which is provided by hwdata.

Signed-off-by: Euan Harris euan.harris@citrix.com
