### PR TITLE
xen-api-xapissl: Put back exec variable, lost in change 1f405f4c

### DIFF
--- a/SOURCES/xen-api-xapissl
+++ b/SOURCES/xen-api-xapissl
@@ -12,7 +12,7 @@ SSLCONFFILE="/etc/xapi/xapissl.conf"
 XAPISSL_LOCK="/var/lock/xapissl"
 
 # If stunnel4 exists, use it. Otherwise use stunnel.
-$(which stunnel4 || which stunnel) 2> /dev/null
+exec=$(which stunnel4 || which stunnel) 2> /dev/null
 
 generate_ssl_cert() {
     local FILE=$1


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
