### PR TITLE
xapi: Release should start at 1 in changelog, too

### DIFF
--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -148,7 +148,7 @@ fi
 /usr/lib/python2.6/site-packages/XenAPIPlugin.pyc
 
 %changelog
-* Mon Sep  1 2013 David Scott <dave.scott@eu.citrix.com> - 1.9.20-0
+* Mon Sep  1 2013 David Scott <dave.scott@eu.citrix.com> - 1.9.20-1
 - Fix XenAPI.py on python2.7
 
 * Tue Aug 20 2013 David Scott <dave.scott@eu.citrix.com> - 1.9.19-1


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
