### PR TITLE
xen-api: Change PAM configuration from password-auth to passwd

### DIFF
--- a/SOURCES/xen-api-pam
+++ b/SOURCES/xen-api-pam
@@ -1,3 +1,3 @@
-auth       include     password-auth
-account    include     password-auth
-password   include     password-auth
+auth       include     passwd
+account    include     passwd
+password   include     passwd


### PR DESCRIPTION
password-auth isn't available on Ubuntu, but passwd is and it
seems to behave equivalently to password-auth on CentOS.

In particular, local non-root users can still call xe commands using:

  xe -u root -pw <password> <command>

Signed-off-by: Euan Harris euan.harris@citrix.com
