### PR TITLE
xenserver-core: Don't depend on openstack-xapi-plugins

### DIFF
--- a/SPECS/xenserver-core.spec
+++ b/SPECS/xenserver-core.spec
@@ -1,6 +1,6 @@
 Name:           xenserver-core
 Version:        0.9.0
-Release:        9
+Release:        10
 Summary:        A virtual package which installs the xapi toolstack
 License:        LGPL
 Group:          Development/Other
@@ -11,7 +11,6 @@ Requires:       xenserver-install-wizard
 Requires:       xapi xapi-xe xe-create-templates xapi-python-devel
 Requires:       xenopsd-xc xenopsd-libvirt xenopsd-xenlight xenopsd-simulator
 Requires:       xenops-cli
-Requires:       openstack-xapi-plugins
 Requires:       ffs xapi-libvirt-storage sm-cli xcp-sm
 Requires:       xcp-networkd
 Requires:       xcp-rrdd
@@ -41,6 +40,9 @@ rm -rf %{buildroot}
 /usr/share/doc/xenserver/README
 
 %changelog
+* Fri Sep 20 2013 Euan Harris <euan.harris@citrix.com>
+- Don't install openstack-xapi-plugins with xenserver-core
+
 * Fri Jun 21 2013 David Scott <dave.scott@eu.citrix.com>
 - Include xenopsd-xenlight
 


### PR DESCRIPTION
Currently we package plugins for the latest stable OpenStack
release.   This causes problems for people who want to run
a development version.   We should not install this package
by default, but keep it available for people who would like
to install the stable OpenStack release.

Signed-off-by: Euan Harris euan.harris@citrix.com
