### PR TITLE
Disable direct running of 'udev' scripts in xenopsd

### DIFF
--- a/SOURCES/xenopsd-conf.in
+++ b/SOURCES/xenopsd-conf.in
@@ -19,3 +19,7 @@ sockets-group=wheel
 
 vncterm=/usr/bin/vncterm
 eliloader=/usr/sbin/eliloader
+
+# Workaround xenopsd bug #45
+run_hotplug_scripts=false
+

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -1,6 +1,6 @@
 Name:           xenopsd
 Version:        0.9.26
-Release:        1
+Release:        2
 Summary:        Simple VM manager
 License:        LGPL
 Group:          Development/Other


### PR DESCRIPTION
Works around djs55/xenopsd#45

Signed-off-by: David Scott dave.scott@eu.citrix.com
