### PR TITLE
ocaml-tapctl: Add runtime dependency on forkexecd

### DIFF
--- a/SPECS/ocaml-tapctl.spec
+++ b/SPECS/ocaml-tapctl.spec
@@ -11,7 +11,7 @@ BuildRequires:  ocaml ocaml-findlib ocaml-camlp4-devel
 BuildRequires:  forkexecd-devel ocaml-stdext-devel ocaml-rpc-devel
 # required by forkexecd
 BuildRequires:  ocaml-syslog-devel
-Requires:       ocaml ocaml-findlib
+Requires:       ocaml ocaml-findlib forkexecd-devel
 
 %description
 Manipulate running tapdisk instances on a xen host.


### PR DESCRIPTION
This change adds a dependency on forkexecd-devel, but
the required files should probably be in the forkexecd
base package.

Signed-off-by: Euan Harris euan.harris@citrix.com
