### PR TITLE
specs: Don't build debuginfo subpackages for OCaml code

### DIFF
--- a/SPECS/biniou.spec
+++ b/SPECS/biniou.spec
@@ -1,3 +1,5 @@
+%define debug_package %{nil}
+
 Name:           biniou
 Version:        1.0.6
 Release:        1

--- a/SPECS/js_of_ocaml.spec
+++ b/SPECS/js_of_ocaml.spec
@@ -1,4 +1,4 @@
-%global debug_package %{nil}
+%define debug_package %{nil}
 
 Name:           js_of_ocaml
 Version:        1.3.2

--- a/SPECS/ocaml-cdrom.spec
+++ b/SPECS/ocaml-cdrom.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-cdrom
 Version:        0.9.1
 Release:        2

--- a/SPECS/ocaml-cstruct.spec
+++ b/SPECS/ocaml-cstruct.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-cstruct
 Version:        0.7.1
 Release:        2

--- a/SPECS/ocaml-fd-send-recv.spec
+++ b/SPECS/ocaml-fd-send-recv.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-fd-send-recv
 Version:        1.0.1
 Release:        1

--- a/SPECS/ocaml-lambda-term.spec
+++ b/SPECS/ocaml-lambda-term.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-lambda-term
 Version:        1.2
 Release:        1

--- a/SPECS/ocaml-libvhd.spec
+++ b/SPECS/ocaml-libvhd.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-libvhd
 Version:        0.9.1
 Release:        1

--- a/SPECS/ocaml-netdev.spec
+++ b/SPECS/ocaml-netdev.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-netdev
 Version:        0.9.0
 Release:        1

--- a/SPECS/ocaml-obuild.spec
+++ b/SPECS/ocaml-obuild.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-obuild
 Version:        0.0.2
 Release:        1

--- a/SPECS/ocaml-ocplib-endian.spec
+++ b/SPECS/ocaml-ocplib-endian.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-ocplib-endian
 Version:        0.4
 Release:        1

--- a/SPECS/ocaml-qmp.spec
+++ b/SPECS/ocaml-qmp.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-qmp
 Version:        0.9.1
 Release:        1

--- a/SPECS/ocaml-sexplib.spec
+++ b/SPECS/ocaml-sexplib.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-sexplib
 Version:        109.20.00
 Release:        1

--- a/SPECS/ocaml-ssl.spec
+++ b/SPECS/ocaml-ssl.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-ssl
 Version:        0.4.6
 Release:        1

--- a/SPECS/ocaml-stdext.spec
+++ b/SPECS/ocaml-stdext.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-stdext
 Version:        0.9.1
 Release:        1

--- a/SPECS/ocaml-tapctl.spec
+++ b/SPECS/ocaml-tapctl.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-tapctl
 Version:        0.9.0
 Release:        1

--- a/SPECS/ocaml-type-conv.spec
+++ b/SPECS/ocaml-type-conv.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-type-conv
 Version:        109.20.00
 Release:        1

--- a/SPECS/ocaml-uri.spec
+++ b/SPECS/ocaml-uri.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-uri
 Version:        1.3.8
 Release:        1

--- a/SPECS/ocaml-uuidm.spec
+++ b/SPECS/ocaml-uuidm.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-uuidm
 Version:        0.9.5
 Release:        1

--- a/SPECS/ocaml-xcp-idl.spec
+++ b/SPECS/ocaml-xcp-idl.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xcp-idl
 Version:        0.9.12
 Release:        1

--- a/SPECS/ocaml-xcp-inventory.spec
+++ b/SPECS/ocaml-xcp-inventory.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xcp-inventory
 Version:        0.9.0
 Release:        1

--- a/SPECS/ocaml-xcp-rrd.spec
+++ b/SPECS/ocaml-xcp-rrd.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xcp-rrd
 Version:        0.9.0
 Release:        1

--- a/SPECS/ocaml-xen-api-client.spec
+++ b/SPECS/ocaml-xen-api-client.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xen-api-client
 Version:        0.9.4
 Release:        1

--- a/SPECS/ocaml-xen-api-libs-transitional.spec
+++ b/SPECS/ocaml-xen-api-libs-transitional.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xen-api-libs-transitional
 Version:        0.9.2
 Release:        1

--- a/SPECS/ocaml-xen-lowlevel-libs.spec
+++ b/SPECS/ocaml-xen-lowlevel-libs.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xen-lowlevel-libs
 Version:        0.9.9
 Release:        1

--- a/SPECS/ocaml-xenops.spec
+++ b/SPECS/ocaml-xenops.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xenops
 Version:        0.9.1
 Release:        1

--- a/SPECS/ocaml-xenstore-clients.spec
+++ b/SPECS/ocaml-xenstore-clients.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xenstore-clients
 Version:        0.9.2
 Release:        1

--- a/SPECS/ocaml-xenstore.spec
+++ b/SPECS/ocaml-xenstore.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-xenstore
 Version:        1.2.4
 Release:        1

--- a/SPECS/ocaml-zed.spec
+++ b/SPECS/ocaml-zed.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           ocaml-zed
 Version:        1.2
 Release:        1


### PR DESCRIPTION
Debuginfo subpackages aren't actually built for OCaml packages,
but the Python RPM library thinks they will be built so makemake.py
produces build rules for them.   Since the targets of the rules are
never actually built, these packages may be rebuilt unnecessarily
during subsequent builds.

The example spec file given in the Fedora OCaml packaging guidelines:

   https://fedoraproject.org/wiki/Packaging:OCaml

Note that the example uses %define (lazily expanded), whereas we are using
%global (eagerly expanded, available in global context).   A comment in
ocaml-re.spec (from upstream) suggests that it is better to use %global
than %define.

Signed-off-by: Euan Harris euan.harris@citrix.com
