### PR TITLE
ocaml-xen-lowlevel-libs: Remove hardcoded dependency on libxl-headers

### DIFF
--- a/SPECS/ocaml-xen-lowlevel-libs.spec
+++ b/SPECS/ocaml-xen-lowlevel-libs.spec
@@ -11,7 +11,7 @@ Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{nam
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-findlib ocaml-camlp4-devel ocaml-ocamldoc
 BuildRequires:  ocaml-lwt-devel xen-devel libuuid-devel cmdliner-devel 
-BuildRequires:  ocaml-cstruct-devel libxl-headers
+BuildRequires:  ocaml-cstruct-devel
 Requires:       ocaml ocaml-findlib
 
 %description

--- a/scripts/mappkgname.py
+++ b/scripts/mappkgname.py
@@ -152,7 +152,7 @@ SECONDARY_MAPPING = {
     "libxapi-libvirt-storage-ocaml": ["libxapi-libvirt-storage-ocaml-dev"],
     "libsexplib-camlp4": ["libsexplib-camlp4-dev"],
     "ocaml-findlib-dev": ["ocaml-findlib", "libfindlib-ocaml-dev"],
-    "xen-hypervisor-dev": ["libxen-dev", "xen-utils", "blktap-dev"],
+    "xen-hypervisor-dev": ["libxen-dev", "xen-utils", "blktap-dev", "libxl-headers"],
     "libvirt0-dev": ["libvirt-dev"],
     "libxen-4.2-dev": ["libxen-dev"],
     "libvirt-bin-dev": ["libvirt-bin"],


### PR DESCRIPTION
libxl-headers is a fixup package needed on Ubuntu, where the
xen-devel packages don't include the libxl headers.   It should
not be in the dependency list in the spec file - we should instead
add it when mapping package names in makedeb.

Signed-off-by: Euan Harris euan.harris@citrix.com
