### PR TITLE
xenops: Update to 0.9.2

### DIFF
--- a/SPECS/ocaml-xenops.spec
+++ b/SPECS/ocaml-xenops.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ocaml-xenops
-Version:        0.9.1
+Version:        0.9.2
 Release:        1
 Summary:        Low-level xen control operations OCaml
 License:        LGPL


### PR DESCRIPTION
0.9.1's META file still requires 'log', which has gone away.

Signed-off-by: Euan Harris euan.harris@citrix.com
