### PR TITLE
makemake: Account for package mapping when generating dependencies

### DIFF
--- a/scripts/mappkgname.py
+++ b/scripts/mappkgname.py
@@ -89,6 +89,7 @@ MAPPING = {
     "xenserver-tech-preview-release": ["xenserver-tech-preview-release"],
     "xmlm": ["libxmlm-ocaml"],
     "xsconsole": ["xsconsole"],
+    "xsconsole0": ["xsconsole"],
     "xsiostat": ["xsiostat"],
     "xenserver-core-latest-snapshot": ["xenserver-core-latest-snapshot"],
     "python-setuptools": ["python-setuptools"],


### PR DESCRIPTION
This change handles Debian-only dependencies which are added
by the package name mapping.

Signed-off-by: Euan Harris euan.harris@citrix.com
