### PR TITLE
pbuilder: Remove avsm OCaml repository

### DIFF
--- a/pbuilderrc.in
+++ b/pbuilderrc.in
@@ -2,7 +2,6 @@ MIRRORSITE="http://gb.archive.ubuntu.com/ubuntu/"
 OTHERMIRROR="deb file:@PWD@/RPMS/ ./|deb-src file:@PWD@/SRPMS/ ./\
 |deb http://ppa.launchpad.net/louis-gesbert/ocp/ubuntu raring main\
 |deb http://gb.archive.ubuntu.com/ubuntu/ raring universe\
-|deb http://ppa.launchpad.net/avsm/ppa/ubuntu raring main\
 |deb-src http://ppa.launchpad.net/avsm/ppa/ubuntu raring main"
 BINDMOUNTS="@PWD@/RPMS @PWD@/SRPMS"
 HOOKDIR="@PWD@/pbuilder"


### PR DESCRIPTION
It doesn't have ocamlfind, and causes conflicts with the OCamlPro
repository, which does have it.

Signed-off-by: Euan Harris euan.harris@citrix.com
