### PR TITLE
configure: Install ocaml to work around spec files which build opt targe...

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -28,7 +28,7 @@ elif [ `lsb_release -si` == "Ubuntu" ] ; then
 	DIST=raring
 	BASETGZ=/var/cache/pbuilder/base-$DIST-$ARCH.tgz
 
-	dpkg -l pbuilder python-rpm curl > /dev/null 2>&1 || sudo apt-get install pbuilder python-rpm curl
+	dpkg -l pbuilder python-rpm curl ocaml-nox > /dev/null 2>&1 || sudo apt-get install pbuilder python-rpm curl ocaml-nox
 	mkdir -p BUILD
 
 	echo -n "Writing pbuilder configuration..."


### PR DESCRIPTION
...ts conditionally

makedeb.py expands the spec file %build recipe on the host,
not in a chroot.   The opt target in the %build recipe of some
spec files, such as ocaml-libvirt, is conditional on the existence
of %{_bindir}/ocamlopt.   If ocaml isn't installed on the host,
the opt target won't be included, even though ocamlopt is available
in the chroot.

Installing ocaml on the build host is a quick workaround;  the proper
fix is either to override the check for %{_bindir}/ocamlopt in the
spec file (harder than you might think to do this neatly) or to
run makedeb in the chroot (slow, but accurate).

Signed-off-by: Euan Harris euan.harris@citrix.com
