### PR TITLE
mappkgname: Install python-setuptools-git along with python-setuptools o...

### DIFF
--- a/scripts/mappkgname.py
+++ b/scripts/mappkgname.py
@@ -92,7 +92,7 @@ MAPPING = {
     "xsconsole0": ["xsconsole"],
     "xsiostat": ["xsiostat"],
     "xenserver-core-latest-snapshot": ["xenserver-core-latest-snapshot"],
-    "python-setuptools": ["python-setuptools"],
+    "python-setuptools": ["python-setuptools", "python-setuptools-git"],
     "vhd-tool": ["vhd-tool"],
 
     # Distribution packages


### PR DESCRIPTION
...n Ubuntu

Needed for openstack-xapi-plugins.

Signed-off-by: Euan Harris euan.harris@citrix.com
