### PR TITLE
debian: Don't waste time regenerating the manpage database

### DIFF
--- a/D05deps.in
+++ b/D05deps.in
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+echo "I: Updating Packages file"
 (cd @PWD@/RPMS; apt-ftparchive packages . > Packages)
+echo "I: Updating Sources file"
 (cd @PWD@/SRPMS; apt-ftparchive sources . > Sources)
 apt-get update

--- a/D10mandb
+++ b/D10mandb
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Don't rebuild man-db
+
+echo "I: Preseed man-db/auto-update to false"
+debconf-set-selections <<EOF
+man-db man-db/auto-update boolean false
+EOF

--- a/configure.sh
+++ b/configure.sh
@@ -36,6 +36,8 @@ elif [ `lsb_release -si` == "Ubuntu" ] ; then
 	sed -e "s|@PWD@|$PWD|g" -e "s|@ARCH@|$ARCH|g" -e "s|@BASETGZ@|$BASETGZ|g" -e "s|@DIST@|$DIST|g" pbuilderrc.in > pbuilder/pbuilderrc-$DIST-$ARCH
 	sed -e "s|@PWD@|$PWD|g" D05deps.in > pbuilder/D05deps
 	chmod 755 pbuilder/D05deps
+	cp D10mandb pbuilder/D10mandb
+	chmod 755 pbuilder/D10mandb
 	echo " done"
 
 	echo -n "Initializing repository..."


### PR DESCRIPTION
By default, APT regenerates the manual page database
after installing packages.   This happens for every
build and takes several seconds, so skipping it should
save quite a lot of time.

Signed-off-by: Euan Harris euan.harris@citrix.com
