### PR TITLE
debian: Prevent apt from calling fsync after each package installation

### DIFF
--- a/D15nofsync
+++ b/D15nofsync
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Stop apt from calling fsync for each package
+
+echo "I: Stop apt from calling fsync for each package"
+echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup

--- a/configure.sh
+++ b/configure.sh
@@ -38,6 +38,8 @@ elif [ `lsb_release -si` == "Ubuntu" ] ; then
 	chmod 755 pbuilder/D05deps
 	cp D10mandb pbuilder/D10mandb
 	chmod 755 pbuilder/D10mandb
+	cp D15nofsync pbuilder/D15nofsync
+	chmod 755 pbuilder/D15nofsync
 	echo " done"
 
 	echo -n "Initializing repository..."


### PR DESCRIPTION
This should speed up the installation of build prerequisites.
https://wiki.ubuntu.com/PbuilderHowto#dpkg_setting

Signed-off-by: Euan Harris euan.harris@citrix.com
