### PR TITLE
debian: Switch to gdebi dependency resolver

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -28,7 +28,8 @@ elif [ `lsb_release -si` == "Ubuntu" ] ; then
 	DIST=raring
 	BASEPATH=/var/cache/pbuilder/base-$DIST-$ARCH.cow
 
-	dpkg -l cowbuilder python-rpm curl ocaml-nox apt-utils > /dev/null 2>&1 || sudo apt-get install cowbuilder python-rpm curl ocaml-nox apt-utils
+	dpkg -l cowbuilder python-rpm curl ocaml-nox apt-utils gdebi-core > /dev/null 2>&1 || \
+           sudo apt-get install cowbuilder python-rpm curl ocaml-nox apt-utils gdebi-core
 	mkdir -p BUILD
 
 	echo -n "Writing pbuilder configuration..."

--- a/pbuilderrc.in
+++ b/pbuilderrc.in
@@ -7,6 +7,7 @@ HOOKDIR="@PWD@/pbuilder"
 EXTRAPACKAGES="apt-utils"
 ALLOWUNTRUSTED=yes
 DISTRIBUTION=@DIST@
+PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-gdebi"
 
 # Architecture specific settings
 ARCHITECTURE=@ARCH@


### PR DESCRIPTION
This should be faster than apt:
https://wiki.ubuntu.com/PbuilderHowto#Speeding_up_build-dependency_calculation

Signed-off-by: Euan Harris euan.harris@citrix.com
