### PR TITLE
debian: Add make install target

### DIFF
--- a/makemake.py
+++ b/makemake.py
@@ -276,3 +276,7 @@ for spec in specs.values():
 
 print "rpms: " + " \\\n\t".join( all_rpms )
 print "srpms: " + " \\\n\t".join( all_srpms )
+
+
+print "install: all" 
+print "\t. scripts/%s/install.sh" % buildType()

--- a/scripts/deb/configure.sh
+++ b/scripts/deb/configure.sh
@@ -7,8 +7,8 @@ ARCH=amd64
 DIST=raring
 BASEPATH=/var/cache/pbuilder/base-$DIST-$ARCH.cow
 
-dpkg -l cowbuilder python-rpm curl ocaml-nox apt-utils gdebi-core > /dev/null 2>&1 || \
-   sudo apt-get install cowbuilder python-rpm curl ocaml-nox apt-utils gdebi-core
+dpkg -l cowbuilder python-rpm curl ocaml-nox apt-utils gdebi-core software-properties-common > /dev/null 2>&1 || \
+   sudo apt-get install cowbuilder python-rpm curl ocaml-nox apt-utils gdebi-core software-properties-common
 mkdir -p BUILD
 
 echo -n "Writing pbuilder configuration..."

--- a/scripts/deb/install.sh
+++ b/scripts/deb/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -x
+
+# Add the OCaml 4 PPA
+install -m 0644 scripts/deb/ocp-ppa.list /etc/apt/sources.list.d/ocp-ppa.list
+
+# Configure the local machine to install packages built in this workspace
+sed -e "s,@PWD@,$PWD,g" scripts/deb/xapi.list.in > scripts/deb/xapi.list
+install -m 0644 scripts/deb/xapi.list /etc/apt/sources.list.d/xapi.list
+
+# Configure apt to prefer packages from the local repository
+install -m 0644 scripts/deb/xapi.preference /etc/apt/preferences.d/xapi
+
+# Install
+apt-get update
+apt-get install -y xenserver-core
+

--- a/scripts/deb/ocp-ppa.list
+++ b/scripts/deb/ocp-ppa.list
@@ -1,0 +1,3 @@
+deb http://ppa.launchpad.net/louis-gesbert/ocp/ubuntu raring main
+deb-src http://ppa.launchpad.net/louis-gesbert/ocp/ubuntu raring main
+

--- a/scripts/deb/xapi.list.in
+++ b/scripts/deb/xapi.list.in
@@ -1,0 +1,2 @@
+deb file:@PWD@/RPMS/ ./
+deb-src file:@PWD@/SRPMS/ ./

--- a/scripts/deb/xapi.pref
+++ b/scripts/deb/xapi.pref
@@ -1,0 +1,4 @@
+Package: *
+Pin: origin ""
+Pin-Priority: 1500
+


### PR DESCRIPTION
This target will configure Apt to install locally-built packages,
and install xenserver-core.

Signed-off-by: Euan Harris euan.harris@citrix.com
