### PR TITLE
Mock: Store mock's cache and chroot in the workspace

### DIFF
--- a/scripts/rpm/configure.sh
+++ b/scripts/rpm/configure.sh
@@ -7,10 +7,14 @@ rpm -q mock rpm-build >/dev/null 2>&1 || sudo yum install -y mock rpm-build
 
 echo -n "Writing mock configuration..."
 mkdir -p mock
-sed "s|@PWD@|$PWD|" scripts/rpm/xenserver.cfg.in > mock/xenserver.cfg
+sed -e "s|@PWD@|$PWD|g" scripts/rpm/xenserver.cfg.in > mock/xenserver.cfg
 ln -fs /etc/mock/default.cfg mock/
 ln -fs /etc/mock/site-defaults.cfg mock/
 ln -fs /etc/mock/logging.ini mock/
+mkdir -p mock/cache
+mkdir -p mock/root
+chgrp mock mock/cache
+chgrp mock mock/root
 echo " done"
 
 echo -n "Initializing repository..."

--- a/scripts/rpm/xenserver.cfg.in
+++ b/scripts/rpm/xenserver.cfg.in
@@ -3,6 +3,8 @@ config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
+config_opts['basedir'] = '@PWD@/mock/root' 
+config_opts['cache_topdir'] = '@PWD@/mock/cache' 
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
By default mock creates chroots in /var/lib/mock and keeps a cache of the
chroot in /var/cache/mock.   Two mock jobs with the same name can't run
simultaneously because the chroot directory in /var/lib/mock is locked.
Even if the chroots have different names, they may still share the same
cache, which can lead to conflicts.

The conflict shows up as one build complaining that 'repomd.xml' from
the chroot (installed from the cache) is newer than repomd.xml from the
repository being built.   This seems to be because one of the builds
writes its repomd.xml back into the cache before the other.

This change stores chroots and caches in the mock subdirectory of
the local workspace.   This means that the chroots and caches can't
conflict, so multiple different builds (from different workspaces)
can run simultaneously.   It does not make it possible to run multiple
simultaneous builds in the same workspace.

There are a few other practical effects of this change:
- A workspace will be about 300MB larger permanently (the size of the
  cache) and will grow by another 300MB or so transiently during the build
  (the size of the temporary chroot).
- Builds on NFS-mounted filesystems with 'root squash' enabled will not work.
  The cache and chroot directories created by mock are owned by root.
- A non-root user cannot delete the contents of the mock/cache and
  mock/root directories directly using 'rm'.  The directories have
  'mock' group ownership and so can be deleted, but the files inside
  them are owned by root.  To delete mock's files, use mock --scrub as follows:
  
    mock --configdir mock -r xenserver --scrub=all

Signed-off-by: Euan Harris euan.harris@citrix.com
