### PR TITLE
makedeb: Need mapping for 'eliloader' because 'linux-guest-loader' still...

### DIFF
--- a/SPECS/linux-guest-loader.spec
+++ b/SPECS/linux-guest-loader.spec
@@ -1,4 +1,4 @@
-Summary: Bootloader for EL-based distros that support Xen
+Summary: Bootloader for EL-based distributions that support Xen
 Name: linux-guest-loader
 Version: 0.9.1
 Release: 1
@@ -14,7 +14,7 @@ Provides:  eliloader > 0.3
 Obsoletes: eliloader <= 0.3
 
 %description
-Bootloader for EL-based distros that support Xen.
+Bootloader for EL-based distributions that support Xen.
 
 %prep
 %setup -q

--- a/scripts/lib/mappkgname.py
+++ b/scripts/lib/mappkgname.py
@@ -12,6 +12,7 @@ MAPPING = {
     "cppo": ["cppo"],
     "deriving-ocsigen": ["libderiving-ocsigen-ocaml"],
     "easy-format": ["libeasy-format-ocaml"],
+    "eliloader": ["eliloader"],
     "linux-guest-loader": ["linux-guest-loader"],
     "xcp-python-libs": ["xcp-python-libs"],
     "ffs": ["ffs"],


### PR DESCRIPTION
... provides it

Signed-off-by: Euan Harris euan.harris@citrix.com
