### PR TITLE
Pkg: Check that specfile name matches package when loading spec

### DIFF
--- a/pkg.py
+++ b/pkg.py
@@ -48,6 +48,12 @@ def map_arch_deb(arch):
         return arch
 
 
+class SpecNameMismatch(Exception):
+    """Exception raised when a spec file's name does not match the name
+       of the package defined within it"""
+    pass
+
+
 class Spec(object):
     """Represents an RPM spec file"""
 
@@ -84,6 +90,11 @@ class Spec(object):
             self.spectext = spec.readlines()
 
         self.spec = rpm.ts().parseSpec(path)
+
+        if os.path.basename(path).split(".")[0] != self.name():
+            raise SpecNameMismatch(
+                "spec file name '%s' does not match package name '%s'" %
+                (path, self.name()))
 
 
     def specpath(self):

--- a/specdep.py
+++ b/specdep.py
@@ -141,21 +141,22 @@ def main():
     specs = {}
 
     for spec_path in params['specs']:
-	if build_type() == "deb":
-            spec = pkg.Spec(spec_path, target="deb",
-                            map_name=map_package_name_deb)
-	else:
-            spec = pkg.Spec(spec_path, target="rpm", dist=params['dist'])
-        pkg_name = spec.name()
-        if pkg_name in params['ignore']:
-            continue
-        if os.path.splitext(os.path.basename(spec_path))[0] != pkg_name:
-            sys.stderr.write(
-                "error: spec file name '%s' does not match package name '%s'\n" %
-                (spec_path, pkg_name))
+        try:
+            if build_type() == "deb":
+                spec = pkg.Spec(spec_path, target="deb",
+                                map_name=map_package_name_deb)
+            else:
+                spec = pkg.Spec(spec_path, target="rpm", dist=params['dist'])
+            pkg_name = spec.name()
+            if pkg_name in params['ignore']:
+                continue
+
+            specs[os.path.basename(spec_path)] = spec
+
+        except pkg.SpecNameMismatch as e:
+            sys.stderr.write("error: %s\n" % e.message)
             sys.exit(1)
 
-        specs[os.path.basename(spec_path)] = spec
 
     provides_to_rpm = package_to_rpm_map(specs.values())
 

--- a/tests/SPECS/bad-name.spec
+++ b/tests/SPECS/bad-name.spec
@@ -1,0 +1,55 @@
+%global debug_package %{nil}
+
+Name:           ocaml-cohttp
+Version:        0.9.8
+Release:        1
+Summary:        An HTTP library for OCaml
+License:        LGPL
+Group:          Development/Other
+URL:            https://github.com/mirage/ocaml-cohttp/archive/ocaml-cohttp-0.9.8.tar.gz
+Source0:        https://github.com/mirage/%{name}/archive/%{name}-%{version}/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  ocaml ocaml-findlib ocaml-re-devel ocaml-uri-devel ocaml-cstruct-devel ocaml-lwt-devel ocaml-ounit-devel ocaml-ocamldoc ocaml-camlp4-devel
+# should these be inherited from ssl.spec somehow?
+BuildRequires:  openssl openssl-devel
+Requires:       ocaml ocaml-findlib
+
+%description
+An HTTP library for OCaml.
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Other
+#Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q -n %{name}-%{name}-%{version}
+
+%build
+make build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_libdir}/ocaml
+export OCAMLFIND_DESTDIR=%{buildroot}/%{_libdir}/ocaml
+ocaml setup.ml -install
+
+%clean
+rm -rf %{buildroot}
+
+%files
+# This space intentionally left blank
+
+%files devel
+%defattr(-,root,root)
+%doc LICENSE README.md CHANGES
+%{_libdir}/ocaml/cohttp/*
+
+%changelog
+* Thu May 30 2013 David Scott <dave.scott@eu.citrix.com>
+- Initial package
+

--- a/tests/SPECS/bad-name.spec.in
+++ b/tests/SPECS/bad-name.spec.in
@@ -1,0 +1,55 @@
+%global debug_package %{nil}
+
+Name:           ocaml-cohttp
+Version:        0.9.8
+Release:        1
+Summary:        An HTTP library for OCaml
+License:        LGPL
+Group:          Development/Other
+URL:            https://github.com/mirage/ocaml-cohttp/archive/ocaml-cohttp-0.9.8.tar.gz
+Source0:        https://github.com/mirage/%{name}/archive/%{name}-%{version}/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  ocaml ocaml-findlib ocaml-re-devel ocaml-uri-devel ocaml-cstruct-devel ocaml-lwt-devel ocaml-ounit-devel ocaml-ocamldoc ocaml-camlp4-devel
+# should these be inherited from ssl.spec somehow?
+BuildRequires:  openssl openssl-devel
+Requires:       ocaml ocaml-findlib
+
+%description
+An HTTP library for OCaml.
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Other
+#Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q -n %{name}-%{name}-%{version}
+
+%build
+make build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_libdir}/ocaml
+export OCAMLFIND_DESTDIR=%{buildroot}/%{_libdir}/ocaml
+ocaml setup.ml -install
+
+%clean
+rm -rf %{buildroot}
+
+%files
+# This space intentionally left blank
+
+%files devel
+%defattr(-,root,root)
+%doc LICENSE README.md CHANGES
+%{_libdir}/ocaml/cohttp/*
+
+%changelog
+* Thu May 30 2013 David Scott <dave.scott@eu.citrix.com>
+- Initial package
+

--- a/tests/SPECS/ocaml-cohttp.spec.in
+++ b/tests/SPECS/ocaml-cohttp.spec.in
@@ -1,0 +1,55 @@
+%global debug_package %{nil}
+
+Name:           ocaml-cohttp
+Version:        0.9.8
+Release:        1
+Summary:        An HTTP library for OCaml
+License:        LGPL
+Group:          Development/Other
+URL:            https://github.com/mirage/ocaml-cohttp/archive/ocaml-cohttp-0.9.8.tar.gz
+Source0:        https://github.com/mirage/%{name}/archive/%{name}-%{version}/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  ocaml ocaml-findlib ocaml-re-devel ocaml-uri-devel ocaml-cstruct-devel ocaml-lwt-devel ocaml-ounit-devel ocaml-ocamldoc ocaml-camlp4-devel
+# should these be inherited from ssl.spec somehow?
+BuildRequires:  openssl openssl-devel
+Requires:       ocaml ocaml-findlib
+
+%description
+An HTTP library for OCaml.
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Other
+#Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q -n %{name}-%{name}-%{version}
+
+%build
+make build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_libdir}/ocaml
+export OCAMLFIND_DESTDIR=%{buildroot}/%{_libdir}/ocaml
+ocaml setup.ml -install
+
+%clean
+rm -rf %{buildroot}
+
+%files
+# This space intentionally left blank
+
+%files devel
+%defattr(-,root,root)
+%doc LICENSE README.md CHANGES
+%{_libdir}/ocaml/cohttp/*
+
+%changelog
+* Thu May 30 2013 David Scott <dave.scott@eu.citrix.com>
+- Initial package
+

--- a/tests/test_pkg.py
+++ b/tests/test_pkg.py
@@ -10,6 +10,15 @@ class RpmTests(unittest.TestCase):
     def setUp(self):
         self.spec = pkg.Spec("SPECS/ocaml-cohttp.spec", dist=".el6")
 
+    def test_good_filename_preprocessor(self):
+        pkg.Spec("tests/SPECS/ocaml-cohttp.spec.in")
+
+    def test_bad_filename(self):
+        self.assertRaises(pkg.SpecNameMismatch, pkg.Spec, "tests/SPECS/bad-name.spec")
+
+    def test_bad_filename_preprocessor(self):
+        self.assertRaises(pkg.SpecNameMismatch, pkg.Spec, "tests/SPECS/bad-name.spec.in")
+
     def test_name(self):
         assert self.spec.name() == "ocaml-cohttp"
 


### PR DESCRIPTION
We only check the first part of the filename, so filenames
such as 'foo.spec.in', which must be preprocessed before use,
will be accepted.

Signed-off-by: Euan Harris euan.harris@citrix.com
