### PR TITLE
test_pkg: Disable name warning for Debian suite's setUp method

### DIFF
--- a/tests/test_pkg.py
+++ b/tests/test_pkg.py
@@ -65,6 +65,8 @@ class RpmTests(unittest.TestCase):
 
 class DebTests(unittest.TestCase):
     def setUp(self):
+        # 'setUp' breaks Pylint's naming rules
+        # pylint: disable=C0103
         def map_rpm_to_deb(name):
             mapping = {"ocaml-cohttp": ["libcohttp-ocaml"],
                        "ocaml-cohttp-devel": ["libcohttp-ocaml-dev"],


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
