### PR TITLE
Mock: Don't store cache and chroot in workspace

### DIFF
--- a/scripts/rpm/xenserver.cfg.in
+++ b/scripts/rpm/xenserver.cfg.in
@@ -3,8 +3,6 @@ config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
-config_opts['basedir'] = '@PWD@/mock/root' 
-config_opts['cache_topdir'] = '@PWD@/mock/cache' 
 
 config_opts['plugin_conf']['package_state_enable'] = False
 config_opts['plugin_conf']['tmpfs_enable'] = True    


### PR DESCRIPTION
This was originally done to make it possible to run builds from
different workspaces simultaneously on the same build machine.
However storing the chroot in the workspace has its own problems
(several hundred megabytes of root-owned files in the workspace).
Container techniques such as Docker or Vagrant are better solutions
to this problem.

Reverts 18c6b64720beaa25dfd991f9d56da3ea70f58d5c

Signed-off-by: Euan Harris euan.harris@citrix.com
