### PR TITLE
Add 'xe': to build the CLI

### DIFF
--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -3,7 +3,7 @@
 Summary: Xen toolstack for XCP
 Name:    xapi
 Version: 1.9.52
-Release: 4%{?dist}
+Release: 5%{?dist}
 License: LGPL+linking exception
 URL:  http://www.xen.org
 Source0: https://github.com/xapi-project/xen-api/archive/v%{version}/xen-api-%{version}.tar.gz
@@ -63,13 +63,6 @@ XCP toolstack.
 %description
 This package contains the xapi toolstack.
 
-%package xe
-Summary: The xapi toolstack CLI
-Requires: bash-completion
-
-%description xe
-The command-line interface for controlling XCP hosts.
-
 %package python-devel
 Summary: XenAPI client support in python
 Requires: python
@@ -107,11 +100,6 @@ mkdir -p %{buildroot}/etc/xapi
 install -m 0644 xen-api-xapi-conf %{buildroot}/etc/xapi.conf
 install -m 0644 xen-api-db-conf %{buildroot}/etc/xapi/db.conf
 
-mkdir -p %{buildroot}/%{_bindir}
-install -m 0755 ocaml/xe-cli/xe.opt %{buildroot}/%{_bindir}/xe
-mkdir -p %{buildroot}/etc/bash_completion.d
-install -m 0755 ocaml/xe-cli/bash-completion %{buildroot}/etc/bash_completion.d/xe
-
 mkdir -p %{buildroot}/var/lib/xapi
 mkdir -p %{buildroot}/etc/xapi/hook-scripts
 
@@ -147,10 +135,6 @@ fi
 /usr/share/xapi/packages/iso
 /etc/pam.d/xapi
 
-%files xe
-%{_bindir}/xe
-/etc/bash_completion.d/xe
-
 %files python-devel
 %{python_sitelib}/XenAPI.py
 %{python_sitelib}/XenAPI.pyo
@@ -161,6 +145,9 @@ fi
 %{python_sitelib}/XenAPIPlugin.pyc
 
 %changelog
+* Fri Oct 3 2014 David Scott <dave.scott@citrix.com> - 1.9.52-5
+- Remove the xe cli (now in a separate package)
+
 * Thu Oct 2 2014 David Scott <dave.scott@citrix.com> - 1.9.52-4
 - Remove ocaml-libvhd dependency
 

--- a/SPECS/xe.spec
+++ b/SPECS/xe.spec
@@ -37,7 +37,7 @@ make
 mkdir -p %{buildroot}/%{_bindir}
 make install BINDIR=%{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/etc/bash-completion.d
-cp src/bash-completion/xe %{buildroot}/etc/bash-completion.d
+cp src/bash-completion %{buildroot}/etc/bash-completion.d/xe
 
 %files
 %{_bindir}/xe

--- a/SPECS/xe.spec
+++ b/SPECS/xe.spec
@@ -1,0 +1,48 @@
+# -*- rpm-spec -*-
+
+Summary: Command-line tools for controlling xapi
+Name:    xe
+Version: 0.6.2
+Release: 1%{?dist}
+Group:   System/Hypervisor
+License: LGPL+linking exception
+URL:  https://github.com/djs55/xapi-xe
+Source0: https://github.com/djs55/xapi-xe/archive/%{version}/%{name}-%{version}.tar.gz
+BuildRequires: ocaml
+BuildRequires: ocaml-camlp4-devel
+BuildRequires: ocaml-findlib
+BuildRequires: ocaml-ocamldoc
+BuildRequires: ocaml-cstruct-devel
+BuildRequires: ocaml-lwt-devel
+BuildRequires: ocaml-ssl-devel
+BuildRequires: openssl-devel
+BuildRequires: ocaml-uuidm-devel
+BuildRequires: ocaml-uri-devel
+BuildRequires: ocaml-cohttp-devel >= 0.10.0
+BuildRequires: ocaml-re-devel
+
+Provides: xapi-xe
+
+%description
+Simple command-line tool for controlling xapi.
+
+%prep 
+%setup -q -n xapi-xe-%{version}
+
+%build
+make
+
+%install
+ 
+mkdir -p %{buildroot}/%{_bindir}
+make install BINDIR=%{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/etc/bash-completion.d
+cp src/bash-completion/xe %{buildroot}/etc/bash-completion.d
+
+%files
+%{_bindir}/xe
+/etc/bash-completion.d/xe
+
+%changelog
+* Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 0.6.2-2
+- Initial package

--- a/SPECS/xenserver-core.spec
+++ b/SPECS/xenserver-core.spec
@@ -8,7 +8,7 @@ Source0:        xenserver-readme
 Requires:       xenserver-install-wizard
 Requires:       xapi
 Requires:       xapi-python-devel
-Requires:       xapi-xe
+Requires:       xe
 Requires:       xe-create-templates
 Requires:       xenopsd-libvirt
 Requires:       xenopsd-simulator


### PR DESCRIPTION
This needs cohttp >= 0.10.0 containing an interface change. A number of packages now need to be updated.

We probably should do this *after* converging xen-api-libs-specs and this repo to avoid excess forking and pain.