### PR TITLE
Resync with xen-api-libs-specs

### DIFF
--- a/SPECS/message-switch.spec
+++ b/SPECS/message-switch.spec
@@ -80,6 +80,7 @@ Group:          Development/Other
 #Requires:       %{name} = %{version}-%{release}
 Requires:       ocaml
 Requires:       ocaml-findlib
+Requires:       ocaml-oclock-devel
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-crc.spec
+++ b/SPECS/ocaml-crc.spec
@@ -1,0 +1,72 @@
+%define debug_package %{nil}
+
+Name:           ocaml-crc
+Version:        0.9.1
+Release:        1
+Summary:        CRC implementation for OCaml
+License:        ISC
+Group:          Development/Other
+URL:            https://github.com/xapi-project/ocaml-crc/
+Source0:        https://github.com/xapi-project/ocaml-crc/archive/%{version}/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  ocaml
+BuildRequires:  ocaml-ocamldoc
+BuildRequires:  ocaml-findlib
+BuildRequires:  ocaml-cstruct-devel
+BuildRequires:  ocaml-ounit-devel
+Requires:       ocaml
+Requires:       ocaml-findlib
+
+%description
+CRC implementation for OCaml, allowing you to compute checksums of cstructs
+and strings.
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Other
+Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q
+
+%build
+ocaml setup.ml -configure --destdir %{buildroot}%{_libdir}/ocaml
+ocaml setup.ml -build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}%{_libdir}/ocaml
+export OCAMLFIND_DESTDIR=%{buildroot}%{_libdir}/ocaml
+export OCAMLFIND_LDCONF=%{buildroot}%{_libdir}/ocaml/ld.conf
+ocaml setup.ml -install
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root)
+%{_libdir}/ocaml/crc/META
+%{_libdir}/ocaml/crc/crc.cma
+%{_libdir}/ocaml/crc/crc.cmi
+%{_libdir}/ocaml/crc/dllcrc_stubs.so
+
+%files devel
+%defattr(-,root,root)
+%doc ChangeLog README.md
+%{_libdir}/ocaml/crc/crc.a
+%{_libdir}/ocaml/crc/crc.cmx
+%{_libdir}/ocaml/crc/crc.cmxa
+%{_libdir}/ocaml/crc/crc.cmxs
+%{_libdir}/ocaml/crc/crc.mli
+%{_libdir}/ocaml/crc/libcrc_stubs.a
+
+%changelog
+* Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 0.9.1-1
+- Update to 0.9.1
+
+* Thu Dec 12 2013 John Else <john.else@citrix.com> - 0.9.0-1
+- Initial package

--- a/SPECS/ocaml-gnt.spec
+++ b/SPECS/ocaml-gnt.spec
@@ -1,0 +1,75 @@
+%define debug_package %{nil}
+
+Name:           ocaml-gnt
+Version:        1.0.0
+Release:        1
+Summary:        OCaml bindings for userspace Xen grant table controls
+License:        LGPL2.1 + OCaml linking exception
+Group:          Development/Other
+URL:            https://github.com/xapi-project/ocaml-gnt/
+Source0:        https://github.com/xapi-project/ocaml-gnt/archive/v%{version}/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  ocaml
+BuildRequires:  ocaml-ocamldoc
+BuildRequires:  ocaml-camlp4-devel
+BuildRequires:  ocaml-findlib
+BuildRequires:  ocaml-cstruct-devel
+BuildRequires:  ocaml-io-page-devel
+BuildRequires:  ocaml-lwt-devel
+BuildRequires:  ocaml-cmdliner-devel
+BuildRequires:  xen-devel
+Requires:       ocaml
+Requires:       ocaml-findlib
+
+%description
+These APIs allow programs running in userspace to share memory with other
+domains on the same host. This can be used to (for example) implement disk
+or network backends.
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Other
+Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-io-page-devel
+Requires:       xen-devel
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q
+
+%build
+make
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}%{_libdir}/ocaml
+export OCAMLFIND_DESTDIR=%{buildroot}%{_libdir}/ocaml
+export OCAMLFIND_LDCONF=%{buildroot}%{_libdir}/ocaml/ld.conf
+ocaml setup.ml -install
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root)
+%doc LICENSE
+%doc ChangeLog README.md
+%{_libdir}/ocaml/xen-gnt
+%exclude %{_libdir}/ocaml/xen-gnt/*.a
+%exclude %{_libdir}/ocaml/xen-gnt/*.cmxa
+%exclude %{_libdir}/ocaml/xen-gnt/*.cmx
+%exclude %{_libdir}/ocaml/xen-gnt/*.ml
+%exclude %{_libdir}/ocaml/xen-gnt/*.mli
+
+%files devel
+%{_libdir}/ocaml/xen-gnt/*.a
+%{_libdir}/ocaml/xen-gnt/*.cmx
+%{_libdir}/ocaml/xen-gnt/*.cmxa
+%{_libdir}/ocaml/xen-gnt/*.mli
+
+%changelog
+* Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 1.0.0-1
+- Initial package

--- a/SPECS/ocaml-rrd-transport.spec
+++ b/SPECS/ocaml-rrd-transport.spec
@@ -1,0 +1,97 @@
+%define debug_package %{nil}
+
+Name:           ocaml-rrd-transport
+Version:        0.7.1
+Release:        1
+Summary:        Shared-memory protocols for transmitting RRD data
+License:        LGPL2.1 + OCaml linking exception
+Group:          Development/Other
+URL:            https://github.com/xapi-project/rrd-transport/
+Source0:        https://github.com/xapi-project/rrd-transport/archive/%{version}/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:  ocaml
+BuildRequires:  ocaml-findlib
+BuildRequires:  ocaml-cstruct-devel
+BuildRequires:  ocaml-crc-devel
+BuildRequires:  ocaml-xcp-rrd-devel
+BuildRequires:  ocaml-xcp-idl-devel
+BuildRequires:  cmdliner-devel
+BuildRequires:  ocaml-gnt-devel
+Requires:       ocaml
+Requires:       ocaml-findlib
+
+%description
+Shared-memory protocol for transmitting RRD data, supporting in-memory files
+and shared Xen pages.
+
+%package        devel
+Summary:        Development files for %{name}
+Group:          Development/Other
+Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-gnt-devel
+Requires:       ocaml-crc-devel
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q -n rrd-transport-%{version}
+
+%build
+ocaml setup.ml -configure --destdir %{buildroot}%{_libdir}/ocaml
+ocaml setup.ml -build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}%{_libdir}/ocaml
+export OCAMLFIND_DESTDIR=%{buildroot}%{_libdir}/ocaml
+export OCAMLFIND_LDCONF=%{buildroot}%{_libdir}/ocaml/ld.conf
+ocaml setup.ml -install
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root)
+%doc LICENSE
+%{_libdir}/ocaml/rrd-transport/META
+%{_libdir}/ocaml/rrd-transport/rrd_transport.cma
+%{_libdir}/ocaml/rrd-transport/rrd_io.cmi
+%{_libdir}/ocaml/rrd-transport/rrd_json.cmi
+%{_libdir}/ocaml/rrd-transport/rrd_protocol.cmi
+%{_libdir}/ocaml/rrd-transport/rrd_protocol_v1.cmi
+%{_libdir}/ocaml/rrd-transport/rrd_protocol_v2.cmi
+%{_libdir}/ocaml/rrd-transport/rrd_reader.cmi
+%{_libdir}/ocaml/rrd-transport/rrd_rpc.cmi
+%{_libdir}/ocaml/rrd-transport/rrd_writer.cmi
+
+%files devel
+%defattr(-,root,root)
+%doc ChangeLog README.md
+%{_libdir}/ocaml/rrd-transport/rrd_transport.a
+%{_libdir}/ocaml/rrd-transport/rrd_transport.cmxa
+%{_libdir}/ocaml/rrd-transport/rrd_transport.cmxs
+%{_libdir}/ocaml/rrd-transport/rrd_io.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_io.mli
+%{_libdir}/ocaml/rrd-transport/rrd_json.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_json.mli
+%{_libdir}/ocaml/rrd-transport/rrd_protocol.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_protocol.mli
+%{_libdir}/ocaml/rrd-transport/rrd_protocol_v1.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_protocol_v1.mli
+%{_libdir}/ocaml/rrd-transport/rrd_protocol_v2.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_protocol_v2.mli
+%{_libdir}/ocaml/rrd-transport/rrd_reader.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_reader.mli
+%{_libdir}/ocaml/rrd-transport/rrd_rpc.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_rpc.mli
+%{_libdir}/ocaml/rrd-transport/rrd_writer.cmx
+%{_libdir}/ocaml/rrd-transport/rrd_writer.mli
+
+%changelog
+* Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 0.7.0-1
+- Update to 0.7.0
+
+* Mon Dec 16 2013 John Else <john.else@citrix.com> - 0.5.0-1
+- Initial package

--- a/SPECS/ocaml-xen-lowlevel-libs.spec
+++ b/SPECS/ocaml-xen-lowlevel-libs.spec
@@ -1,8 +1,8 @@
 %global debug_package %{nil}
 
 Name:           ocaml-xen-lowlevel-libs
-Version:        0.9.9
-Release:        3%{?dist}
+Version:        0.9.14
+Release:        1%{?dist}
 Summary:        Xen hypercall bindings for OCaml
 License:        LGPL
 Group:          Development/Libraries
@@ -34,6 +34,8 @@ developing applications that use %{name}.
 %setup -q
 
 %build
+make configure
+./configure --disable-xenlight
 make
 
 %install
@@ -58,30 +60,11 @@ make install DESTDIR=${buildroot}
 #%{_libdir}/ocaml/stublibs/dllxentoollog_stubs.so
 #%{_libdir}/ocaml/stublibs/dllxentoollog_stubs.so.owner
 
-%exclude %{_libdir}/ocaml/stublibs/dllxenlight_stubs.so
-%exclude %{_libdir}/ocaml/stublibs/dllxenlight_stubs.so.owner
-%exclude %{_libdir}/ocaml/stublibs/dllxentoollog_stubs.so
-%exclude %{_libdir}/ocaml/stublibs/dllxentoollog_stubs.so.owner
-%exclude %{_libdir}/ocaml/xenlight/META
-%exclude %{_libdir}/ocaml/xenlight/libxenlight_stubs.a
-%exclude %{_libdir}/ocaml/xenlight/libxentoollog_stubs.a
-%exclude %{_libdir}/ocaml/xenlight/xenlight.a
-%exclude %{_libdir}/ocaml/xenlight/xenlight.cma
-%exclude %{_libdir}/ocaml/xenlight/xenlight.cmi
-%exclude %{_libdir}/ocaml/xenlight/xenlight.cmx
-%exclude %{_libdir}/ocaml/xenlight/xenlight.cmxa
-%exclude %{_libdir}/ocaml/xenlight/xenlight.cmxs
-%exclude %{_libdir}/ocaml/xenlight/xenlight.mli
-%exclude %{_libdir}/ocaml/xenlight/xentoollog.a
-%exclude %{_libdir}/ocaml/xenlight/xentoollog.cma
-%exclude %{_libdir}/ocaml/xenlight/xentoollog.cmi
-%exclude %{_libdir}/ocaml/xenlight/xentoollog.cmx
-%exclude %{_libdir}/ocaml/xenlight/xentoollog.cmxa
-%exclude %{_libdir}/ocaml/xenlight/xentoollog.cmxs
-%exclude %{_libdir}/ocaml/xenlight/xentoollog.mli
-
 
 %changelog
+* Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 0.9.12-1
+- Update to 0.9.14
+
 * Mon Oct 21 2013 David Scott <dave.scott@eu.citrix.com> - 0.9.9-3
 - Exclude the xenlight stuff in case it manages to build
 

--- a/SPECS/xapi-libvirt-storage.spec
+++ b/SPECS/xapi-libvirt-storage.spec
@@ -1,5 +1,5 @@
 Name:           xapi-libvirt-storage
-Version:        0.9.7
+Version:        0.9.8
 Release:        1%{?dist}
 Summary:        Allows the manipulation of libvirt storage pools and volumes via xapi
 License:        LGPL
@@ -12,7 +12,6 @@ BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-libvirt-devel
-BuildRequires:  ocaml-obuild
 BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-cmdliner-devel
@@ -34,7 +33,7 @@ make
 
 %install
 mkdir -p %{buildroot}/%{_sbindir}
-install dist/build/sm-libvirt/sm-libvirt %{buildroot}/%{_sbindir}/xapi-libvirt-storage
+install main.native %{buildroot}/%{_sbindir}/xapi-libvirt-storage
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
 install -m 0755 xapi-libvirt-storage-init %{buildroot}%{_sysconfdir}/init.d/xapi-libvirt-storage
 
@@ -54,6 +53,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 0.9.8-1
+- Update to 0.9.8
+
 * Wed Sep 25 2013 David Scott <dave.scott@eu.citrix.com> - 0.9.7-1
 - Update to 0.9.7
 

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -2,7 +2,7 @@
 
 Summary: Xen toolstack for XCP
 Name:    xapi
-Version: 1.9.39
+Version: 1.9.40
 Release: 1%{?dist}
 Group:   System/Hypervisor
 License: LGPL+linking exception
@@ -170,6 +170,9 @@ fi
 %{python_sitelib}/XenAPIPlugin.pyc
 
 %changelog
+* Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 1.9.40-1
+- update to new xcp-idl interface with SR.probe
+
 * Wed Apr 2 2014 Euan Harris <euan.harris@citrix.com> - 1.9.39-1
 - update to 1.9.39 - switch from stdext's Tar to ocaml-tar
 

--- a/SPECS/xcp-rrdd.spec
+++ b/SPECS/xcp-rrdd.spec
@@ -1,5 +1,5 @@
 Name:           xcp-rrdd
-Version:        0.9.2
+Version:        0.9.4
 Release:        1%{?dist}
 Summary:        Statistics gathering daemon for the xapi toolstack
 License:        LGPL
@@ -17,9 +17,9 @@ BuildRequires:  ocaml-cohttp-devel
 BuildRequires:  ocaml-re-devel
 BuildRequires:  ocaml-xcp-inventory-devel
 BuildRequires:  ocaml-xen-api-libs-transitional-devel
-BuildRequires:  ocaml-xen-lowlevel-libs-devel
 BuildRequires:  ocaml-xenops-devel
 BuildRequires:  ocaml-oclock-devel
+BuildRequires:  ocaml-rrd-transport-devel
 BuildRequires:  forkexecd-devel
 BuildRequires:  message-switch-devel
 BuildRequires:  xen-devel
@@ -57,6 +57,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Sat Apr 26 2014 David Scott <dave.scott@eu.citrix.com> - 0.9.3-1
+- Update to 0.9.4, now depends on rrdd-transport
+
 * Wed Sep 25 2013 David Scott <dave.scott@eu.citrix.com> - 0.9.2-1
 - Update to 0.9.2
 


### PR DESCRIPTION
In particular we're now using ocaml-gnt for grant tables, we have
updated xcp-idl to include SR.probe and we have explicitly disabled
xenlight.

Signed-off-by: David Scott dave.scott@citrix.com
