### PR TITLE
SPECS: Great dependency spring-cleaning

### DIFF
--- a/SPECS/ffs.spec
+++ b/SPECS/ffs.spec
@@ -8,7 +8,6 @@ URL:            https://github.com/xapi-project/ffs
 Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 Source1:        ffs-init
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-obuild
 BuildRequires:  ocaml-rpc-devel
@@ -16,15 +15,9 @@ BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-cmdliner-devel
 BuildRequires:  ocaml-cohttp-devel
 BuildRequires:  ocaml-re-devel
-BuildRequires:  libuuid-devel
 BuildRequires:  ocaml-libvhd-devel
-BuildRequires:  ocaml-oclock-devel
-BuildRequires:  xen-devel
-BuildRequires:  forkexecd-devel
-BuildRequires:  message-switch-devel
 BuildRequires:  ocaml-tapctl-devel
 Requires:       nfs-utils
-Requires:       ocaml-libvhd-devel
 Requires:       redhat-lsb-core
 Requires:       blktap
 

--- a/SPECS/forkexecd.spec
+++ b/SPECS/forkexecd.spec
@@ -8,16 +8,13 @@ URL:            https://github.com/xapi-project/forkexecd
 Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 Source1:        forkexecd-init
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-fd-send-recv-devel
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-re-devel
 BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-stdext-devel
 BuildRequires:  ocaml-uuidm-devel
 BuildRequires:  ocaml-xcp-idl-devel
-Requires:  ocaml-rpc-devel
 Requires:  redhat-lsb-core
 Requires(post): chkconfig
 Requires(preun): chkconfig
@@ -64,8 +61,11 @@ fi
 Summary:        Development files for %{name}
 Group:          Development/Other
 Requires:       %{name} = %{version}-%{release}
-Requires:       ocaml
-Requires:       ocaml-findlib
+Requires:       ocaml-fd-send-recv-devel%{?_isa}
+Requires:       ocaml-rpc-devel%{?_isa}
+Requires:       ocaml-stdext-devel%{?_isa}
+Requires:       ocaml-uuidm-devel%{?_isa}
+Requires:       ocaml-xcp-idl-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/js_of_ocaml.spec
+++ b/SPECS/js_of_ocaml.spec
@@ -14,8 +14,6 @@ BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib-devel
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-ocamldoc
-Requires:       deriving-ocsigen-devel
-Requires:       ocaml-lwt-devel
 
 %description
 Compile OCaml programs to Javascript.
@@ -24,6 +22,7 @@ Compile OCaml programs to Javascript.
 Summary:        Development files for %{name}
 Group:          Development/Other
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-lwt-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/message-switch.spec
+++ b/SPECS/message-switch.spec
@@ -12,31 +12,14 @@ BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires: ocaml-cohttp-devel
 BuildRequires: ocaml-rpc-devel
-BuildRequires: ocaml-xenstore-devel
-BuildRequires: ocaml-ounit-devel
-BuildRequires: ocaml-uri-devel
 BuildRequires: ocaml-cmdliner-devel
 BuildRequires: ocaml-re-devel
 BuildRequires: ocaml-rpc-devel
 BuildRequires: ocaml-oclock-devel
-BuildRequires: ocaml-ssl-devel
-BuildRequires: openssl-devel
 Requires:      redhat-lsb-core
 Requires(post): chkconfig
 Requires(preun): chkconfig
 Requires(preun): initscripts
-#  "ocamlfind"
-#  "cohttp" {= "0.9.7"}
-#  "rpc"
-#  "xenstore"
-#  "ounit"
-#  "syslog"
-#  "uri"
-#  "re"
-#  "rpc"
-#  "cmdliner"
-#  "ssl"
-#  "oclock"
 
 %description
 A store and forward message switch for OCaml.
@@ -77,10 +60,11 @@ fi
 %package        devel
 Summary:        Development files for %{name}
 Group:          Development/Other
-#Requires:       %{name} = %{version}-%{release}
-Requires:       ocaml
-Requires:       ocaml-findlib
-Requires:       ocaml-oclock-devel
+Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-cohttp-devel%{?_isa}
+Requires:       ocaml-oclock-devel%{?_isa}
+Requires:       ocaml-re-devel%{?_isa}
+Requires:       ocaml-rpc-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/oasis.spec
+++ b/SPECS/oasis.spec
@@ -24,6 +24,7 @@ your project and creates everything required.
 %package        devel
 Summary:        Development files for %{name}
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-odn-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-biniou.spec
+++ b/SPECS/ocaml-biniou.spec
@@ -21,6 +21,7 @@ compatibility as protocols evolve.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-easy-format-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-cohttp.spec
+++ b/SPECS/ocaml-cohttp.spec
@@ -10,7 +10,6 @@ URL:            https://github.com/mirage/ocaml-cohttp
 Source0:        https://github.com/mirage/%{name}/archive/%{name}-%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
-BuildRequires:  ocaml-cstruct-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-ocamldoc
@@ -27,6 +26,9 @@ An HTTP library for OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-lwt-devel%{?_isa}
+Requires:       ocaml-re-devel%{?_isa}
+Requires:       ocaml-uri-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-cstruct.spec
+++ b/SPECS/ocaml-cstruct.spec
@@ -13,8 +13,6 @@ BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-ocplib-endian-devel
-Requires:       ocaml-ocplib-endian-devel
-#XXX ocaml-cstruct should require caml-ocplib-endian, not -devel
 
 %description
 Read and write low-level C-style structures in OCaml.
@@ -23,6 +21,7 @@ Read and write low-level C-style structures in OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-ocplib-endian-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-io-page.spec
+++ b/SPECS/ocaml-io-page.spec
@@ -23,6 +23,7 @@ IO pages are page-aligned, and wrapped in the Cstruct library to avoid copying t
 Summary:        Development files for %{name}
 Group:          Development/Other
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-cstruct-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-lambda-term.spec
+++ b/SPECS/ocaml-lambda-term.spec
@@ -24,6 +24,8 @@ Lambda-Term is a cross-platform library for manipulating the terminal.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-lwt-devel%{?_isa}
+Requires:       ocaml-zed-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-libvhd.spec
+++ b/SPECS/ocaml-libvhd.spec
@@ -20,6 +20,8 @@ Simple C bindings which allow .vhd files to be manipulated.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       libuuid-devel%{?_isa}
+Requires:       xen-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-mirage-types.spec
+++ b/SPECS/ocaml-mirage-types.spec
@@ -26,6 +26,8 @@ See http://openmirage.org for more information.
 Summary:        Development files for %{name}
 Group:          Development/Other
 Requires:       %{name} = %{version}-%{release}
+BuildRequires:  ocaml-ipaddr-devel%{?_isa}
+BuildRequires:  ocaml-lwt-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-nbd.spec
+++ b/SPECS/ocaml-nbd.spec
@@ -26,6 +26,7 @@ access remote block devices.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+BuildRequires:  ocaml-cstruct-devel%{?_isa}
 
 
 %description    devel

--- a/SPECS/ocaml-netdev.spec
+++ b/SPECS/ocaml-netdev.spec
@@ -11,9 +11,7 @@ Source0:        https://github.com/xapi-project/netdev/archive/netdev-%{version}
 BuildRequires:  forkexecd-devel
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-stdext-devel
-BuildRequires:  ocaml-xcp-idl-devel
 
 %description
 Manipulate Linux bridges, network devices and openvswitch instances in OCaml.
@@ -22,6 +20,8 @@ Manipulate Linux bridges, network devices and openvswitch instances in OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+BuildRequires:  forkexecd-devel%{?_isa}
+BuildRequires:  ocaml-stdext-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-odn.spec
+++ b/SPECS/ocaml-odn.spec
@@ -21,6 +21,7 @@ BuildRequires:	ocaml-fileutils-devel >= 0.4.0
 %package        devel
 Summary:        Development files for %{name}
 Requires:       %{name} = %{version}-%{release}
+BuildRequires:	ocaml-type-conv%{_isa} >= 108.07.01
 
 
 %description    devel

--- a/SPECS/ocaml-qmp.spec
+++ b/SPECS/ocaml-qmp.spec
@@ -24,6 +24,7 @@ process.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-yojson-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-rpc.spec
+++ b/SPECS/ocaml-rpc.spec
@@ -22,6 +22,9 @@ Am RPC library for OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-camlp4-devel%{?_isa}
+Requires:       ocaml-type-conv%{?_isa}
+Requires:       xmlm-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-sexplib.spec
+++ b/SPECS/ocaml-sexplib.spec
@@ -23,6 +23,8 @@ Convert values to and from s-expressions in OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-camlp4-devel%{?_isa}
+Requires:       ocaml-type-conv%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-ssl.spec
+++ b/SPECS/ocaml-ssl.spec
@@ -19,6 +19,7 @@ Use OpenSSL from OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       openssl-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-stdext.spec
+++ b/SPECS/ocaml-stdext.spec
@@ -20,6 +20,8 @@ Deprecated misc library functions for OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-fd-send-recv-devel%{?_isa}
+BuildRequires:  ocaml-uuidm-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-tapctl.spec
+++ b/SPECS/ocaml-tapctl.spec
@@ -12,10 +12,8 @@ BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  forkexecd-devel
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-stdext-devel
-BuildRequires:  ocaml-xcp-idl-devel
 
 %description
 Manipulate running tapdisk instances on a xen host.
@@ -25,6 +23,8 @@ Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
 Requires:       forkexecd-devel%{?_isa}
+Requires:       ocaml-rpc-devel%{?_isa}
+Requires:       ocaml-stdext-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-tar.spec
+++ b/SPECS/ocaml-tar.spec
@@ -9,12 +9,9 @@ Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{nam
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-ounit-devel
-# These are build requires which are also requires of the -devel package
 BuildRequires:  ocaml-cstruct-devel
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-re-devel
-# These are build requires which should be requires of some of the -devel
-# packages -- update the devel packages later
 BuildRequires:  ocaml-camlp4-devel
 
 %description
@@ -24,12 +21,9 @@ This is a pure OCaml library for reading and writing tar-format data.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
-Requires:       ocaml-cstruct-devel
-Requires:       ocaml-lwt-devel
-Requires:       ocaml-re-devel
-# These are requires which should be requires of some of the -devel
-# packages -- update the devel packages later
-Requires:       ocaml-camlp4
+Requires:       ocaml-cstruct-devel%{?_isa}
+Requires:       ocaml-lwt-devel%{?_isa}
+Requires:       ocaml-re-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-uri.spec
+++ b/SPECS/ocaml-uri.spec
@@ -21,6 +21,7 @@ A URI library for OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Other
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-re-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-vhd.spec
+++ b/SPECS/ocaml-vhd.spec
@@ -10,7 +10,6 @@ URL:            http://github.com/djs55/ocaml-vhd
 Source0:        https://github.com/djs55/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
-BuildRequires:  ocaml-cmdliner-devel
 BuildRequires:  ocaml-cstruct-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-lwt-devel
@@ -27,7 +26,12 @@ vhd files to be read, written and streamed with on-the-fly format conversion.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
-
+Requires:       ocaml-cstruct-devel%{?_isa}
+Requires:       ocaml-io-page-devel%{?_isa}
+Requires:       ocaml-lwt-devel%{?_isa}
+Requires:       ocaml-ounit-devel%{?_isa}
+Requires:       ocaml-mirage-types-devel%{?_isa}
+Requires:       ocaml-uuidm-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-xcp-idl.spec
+++ b/SPECS/ocaml-xcp-idl.spec
@@ -21,9 +21,6 @@ BuildRequires:  ocaml-xcp-rrd-devel
 BuildRequires:  xmlm-devel
 BuildRequires:  ocaml-ounit-devel
 
-# XXX transitive dependencies of message-switch-devel
-BuildRequires: ocaml-oclock-devel
-
 %description
 Common interface definitions for XCP services.
 
@@ -31,7 +28,13 @@ Common interface definitions for XCP services.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
-Requires:       message-switch-devel
+Requires:       message-switch-devel%{?_isa}
+Requires:       ocaml-uri-devel%{?_isa}
+Requires:       ocaml-re-devel%{?_isa}
+Requires:       ocaml-cohttp-devel%{?_isa}
+Requires:       ocaml-rpc-devel%{?_isa}
+Requires:       ocaml-fd-send-recv-devel%{?_isa}
+Requires:       xmlm-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-xcp-inventory.spec
+++ b/SPECS/ocaml-xcp-inventory.spec
@@ -22,6 +22,8 @@ A simple library to read and write the XCP inventory file.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-stdext-devel%{?_isa}
+Requires:       ocaml-uuidm-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-xcp-rrd.spec
+++ b/SPECS/ocaml-xcp-rrd.spec
@@ -22,6 +22,8 @@ Round-Robin Datasources in OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-rpc-devel%{?_isa}
+Requires:       ocaml-stdext-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-xen-api-client.spec
+++ b/SPECS/ocaml-xen-api-client.spec
@@ -15,9 +15,7 @@ BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-ounit-devel
 BuildRequires:  ocaml-rpc-devel
-BuildRequires:  ocaml-ssl-devel
 BuildRequires:  ocaml-uri-devel
-BuildRequires:  openssl-devel
 BuildRequires:  xmlm-devel
 
 %description
@@ -29,6 +27,12 @@ virtualization hosts.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       xmlm-devel%{?_isa}
+Requires:       ocaml-cohttp-devel%{?_isa}
+Requires:       ocaml-rpc-devel%{?_isa}
+Requires:       ocaml-lwt-devel%{?_isa}
+Requires:       ocaml-uri-devel%{?_isa}
+Requires:       ocaml-cstruct-devel%{?_isa}
 
 %description    devel
 XenAPI Client is an OCaml library implementing XenServer's XenAPI.

--- a/SPECS/ocaml-xen-api-libs-transitional.spec
+++ b/SPECS/ocaml-xen-api-libs-transitional.spec
@@ -19,7 +19,6 @@ BuildRequires:  ocaml-xenstore-devel
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-xenstore-clients-devel
 BuildRequires:  xen-devel
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-xcp-idl-devel
 Requires:       xen-libs
 

--- a/SPECS/ocaml-xenops.spec
+++ b/SPECS/ocaml-xenops.spec
@@ -12,12 +12,9 @@ BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-obuild
-BuildRequires:  ocaml-rpc-devel
-BuildRequires:  ocaml-stdext-devel
 BuildRequires:  ocaml-xen-lowlevel-libs-devel
 BuildRequires:  ocaml-xenstore-clients-devel
 BuildRequires:  ocaml-xenstore-devel
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-xen-api-libs-transitional-devel
 
@@ -28,6 +25,11 @@ Low-level xen control operations in OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-xcp-idl-devel%{?_isa}
+Requires:       ocaml-stdext-devel%{?_isa}
+Requires:       ocaml-xen-lowlevel-libs-devel%{?_isa}
+Requires:       ocaml-xenstore-devel%{?_isa}
+Requires:       ocaml-xenstore-clients-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-xenstore-clients.spec
+++ b/SPECS/ocaml-xenstore-clients.spec
@@ -21,6 +21,8 @@ Unix xenstore clients for OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-lwt-devel%{?_isa}
+Requires:       ocaml-xenstore-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-xenstore.spec
+++ b/SPECS/ocaml-xenstore.spec
@@ -23,6 +23,8 @@ An implementation of the xenstore protocol in OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-cstruct-devel%{?_isa}
+Requires:       ocaml-lwt-devel%{?_isa}
 Conflicts:      xen-ocaml-devel
 
 %description    devel

--- a/SPECS/ocaml-yojson.spec
+++ b/SPECS/ocaml-yojson.spec
@@ -21,6 +21,8 @@ A JSON parser and printer for OCaml.
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-biniou-devel%{?_isa}
+Requires:       ocaml-easy-format-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/ocaml-zed.spec
+++ b/SPECS/ocaml-zed.spec
@@ -22,6 +22,8 @@ text editors, edition widgets, readlines, ...
 Summary:        Development files for %{name}
 Group:          Development/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       ocaml-camomile-devel%{?_isa}
+Requires:       ocaml-react-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for

--- a/SPECS/sm-cli.spec
+++ b/SPECS/sm-cli.spec
@@ -7,17 +7,12 @@ Group:          Development/Other
 URL:            https://github.com/xapi-project/sm-cli
 Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-cmdliner-devel
 BuildRequires:  ocaml-obuild
-BuildRequires:  ocaml-uuidm-devel
+BuildRequires:  ocaml-re-devel
+BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-xcp-idl-devel
-BuildRequires:  message-switch-devel
-Requires:       message-switch
-
-# XXX transitively required by message_switch
-BuildRequires:  ocaml-oclock-devel
 
 %description
 Command-line interface for xapi toolstack storage managers.

--- a/SPECS/squeezed.spec
+++ b/SPECS/squeezed.spec
@@ -8,12 +8,9 @@ URL:            https://github.com/xapi-project/squeezed
 Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 Source1:        squeezed-init
 Source2:        squeezed-conf
-BuildRequires:  message-switch-devel
 BuildRequires:  oasis
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-re-devel
 BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-stdext-devel
@@ -22,7 +19,6 @@ BuildRequires:  ocaml-xen-lowlevel-libs-devel
 BuildRequires:  ocaml-xenstore-clients-devel
 BuildRequires:  ocaml-xenstore-devel
 BuildRequires:  xen-devel
-Requires:       xen-libs
 Requires:       redhat-lsb-core
 Requires:       message-switch
 

--- a/SPECS/utop.spec
+++ b/SPECS/utop.spec
@@ -11,7 +11,6 @@ BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-ocamldoc
 BuildRequires:  ocaml-lambda-term-devel
-BuildRequires:  ocaml-zed-devel
 Requires: ocaml-camomile-data
 
 %description

--- a/SPECS/vhd-tool.spec
+++ b/SPECS/vhd-tool.spec
@@ -10,32 +10,19 @@ URL:  https://github.com/xapi-project/vhd-tool
 Source0: https://github.com/xapi-project/vhd-tool/archive/v%{version}/%{name}-%{version}.tar.gz
 Source1: vhd-tool-sparse_dd-conf
 BuildRequires: ocaml
-BuildRequires: ocaml-camlp4-devel
 BuildRequires: ocaml-findlib
 BuildRequires: ocaml-ocamldoc
-BuildRequires: ocaml-obuild
 BuildRequires: ocaml-vhd-devel
 BuildRequires: ocaml-xcp-idl-devel
-BuildRequires: ocaml-cstruct-devel
 BuildRequires: ocaml-lwt-devel
 BuildRequires: ocaml-nbd-devel
-BuildRequires: ocaml-ounit-devel
-BuildRequires: ocaml-rpc-devel
-BuildRequires: ocaml-ssl-devel
-BuildRequires: ocaml-stdext-devel
 BuildRequires: ocaml-tapctl-devel
-BuildRequires: ocaml-xen-lowlevel-libs-devel
 BuildRequires: ocaml-cmdliner-devel
-BuildRequires: git
-BuildRequires: ocaml-oclock-devel
 BuildRequires: ocaml-xenstore-devel
-BuildRequires: libuuid-devel
 BuildRequires: ocaml-io-page-devel
 BuildRequires: ocaml-sha-devel
 BuildRequires: ocaml-tar-devel
-BuildRequires: message-switch-devel
 BuildRequires: ocaml-xenstore-clients-devel
-BuildRequires: openssl-devel
 
 %description
 Simple command-line tools for manipulating and streaming .vhd format file.

--- a/SPECS/xapi-libvirt-storage.spec
+++ b/SPECS/xapi-libvirt-storage.spec
@@ -9,7 +9,6 @@ Source0:        https://github.com/xapi-project/%{name}/archive/%{version}/%{nam
 Source1:        xapi-libvirt-storage-init
 BuildRequires:  libvirt-devel
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-libvirt-devel
 BuildRequires:  ocaml-rpc-devel
@@ -17,8 +16,6 @@ BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-cmdliner-devel
 BuildRequires:  ocaml-cohttp-devel
 BuildRequires:  ocaml-re-devel
-BuildRequires:  ocaml-oclock-devel
-BuildRequires:  message-switch-devel
 Requires:       redhat-lsb-core
 
 %description

--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -11,7 +11,6 @@ Source2:        xcp-networkd-conf
 Source3:        xcp-networkd-network-conf
 Source4:        xcp-networkd-bridge-conf
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-obuild
 BuildRequires:  ocaml-rpc-devel
@@ -21,12 +20,7 @@ BuildRequires:  ocaml-stdext-devel
 BuildRequires:  ocaml-xen-api-libs-transitional-devel
 BuildRequires:  ocaml-ounit-devel
 BuildRequires:  ocaml-xcp-inventory-devel
-BuildRequires:  ocaml-cmdliner-devel
-BuildRequires:  ocaml-cohttp-devel
-BuildRequires:  ocaml-re-devel
 BuildRequires:  ocaml-xen-api-client-devel
-BuildRequires:  message-switch-devel
-BuildRequires:  ocaml-oclock-devel
 Requires:       ethtool
 Requires:       redhat-lsb-core
 

--- a/SPECS/xcp-rrdd.spec
+++ b/SPECS/xcp-rrdd.spec
@@ -13,15 +13,10 @@ BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-obuild
 BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-xcp-idl-devel
-BuildRequires:  ocaml-cohttp-devel
-BuildRequires:  ocaml-re-devel
 BuildRequires:  ocaml-xcp-inventory-devel
-BuildRequires:  ocaml-xen-api-libs-transitional-devel
 BuildRequires:  ocaml-xenops-devel
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-rrd-transport-devel
 BuildRequires:  forkexecd-devel
-BuildRequires:  message-switch-devel
 BuildRequires:  xen-devel
 Requires:       redhat-lsb-core
 

--- a/SPECS/xe-create-templates.spec
+++ b/SPECS/xe-create-templates.spec
@@ -13,12 +13,9 @@ BuildRequires:  ocaml-obuild
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-stdext-devel
 BuildRequires:  xmlm-devel
-BuildRequires:  ocaml-xen-api-libs-transitional-devel
-BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-xen-api-client-devel
 BuildRequires:  ocaml-xcp-idl-devel
-BuildRequires:  openssl-devel
-Requires:       openssl
+BuildRequires:  ocaml-xen-api-libs-transitional-devel
 
 %description
 A utility to create the default XenServer templates.

--- a/SPECS/xenops-cli.spec
+++ b/SPECS/xenops-cli.spec
@@ -7,17 +7,11 @@ Group:          Development/Other
 URL:            https://github.com/xapi-project/xenops-cli
 Source0:        https://github.com/xapi-project/%{name}/archive/%{name}-%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-cmdliner-devel
-BuildRequires:  ocaml-obuild
+BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-uuidm-devel
 BuildRequires:  ocaml-xcp-idl-devel
-BuildRequires:  message-switch-devel
-Requires:       message-switch
-
-# XXX transitively required by message_switch
-BuildRequires:  ocaml-oclock-devel
 
 %description
 Command-line interface for xenopsd, the xapi toolstack domain manager.

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -13,14 +13,11 @@ Source4:        xenopsd-xenlight-init
 Source5:        make-xsc-xenopsd.conf
 Source6:        xenopsd-network-conf
 BuildRequires:  ocaml
-BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
-BuildRequires:  ocaml-obuild
 BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-cmdliner-devel
 BuildRequires:  ocaml-cohttp-devel
-BuildRequires:  ocaml-re-devel
 BuildRequires:  forkexecd-devel
 BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-uuidm-devel
@@ -31,16 +28,14 @@ BuildRequires:  ocaml-sexplib-devel
 BuildRequires:  ocaml-xen-lowlevel-libs-devel
 BuildRequires:  ocaml-xenstore-clients-devel
 BuildRequires:  ocaml-xenstore-devel
-BuildRequires:  message-switch-devel
 BuildRequires:  ocaml-xcp-inventory-devel
 BuildRequires:  xen-devel
-BuildRequires:  linux-guest-loader
-BuildRequires:  ocaml-xcp-idl-devel
-BuildRequires:  vncterm
 BuildRequires:  ocaml-uutf-devel
 Requires:       message-switch
 Requires:       redhat-lsb-core
 Requires:       xenops-cli
+Requires:       vncterm
+Requires:       linux-guest-loader
 
 %description
 Simple VM manager for the xapi toolstack.


### PR DESCRIPTION
In general, an OCaml package's BuildRequires are based on the dependencies
declared in its _oasis file (or similar), and its -devel package's
Requires are based on the dependencies declared in its META file.
- Remove unneeded dependencies
- Add runtime dependencies for -devel packages
