### PR TITLE
rpm/configure: Initialize repository metadata in SRPMS directory

### DIFF
--- a/scripts/rpm/configure.sh
+++ b/scripts/rpm/configure.sh
@@ -21,5 +21,6 @@ echo -n "Initializing repository..."
 mkdir -p RPMS
 createrepo --quiet RPMS
 mkdir -p SRPMS
+createrepo --quiet SRPMS
 echo " done"
 


### PR DESCRIPTION
We now generate repository metadata after building SRPMs - this
change silences a warning about missing metadata printed because
the metadata does not exist and can't be updated after the first
SRPM is built.

Signed-off-by: Euan Harris euan.harris@citrix.com
