### PR TITLE
Parallel make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,18 @@ all: rpms
 %.dsc: 
 	@echo [MAKEDEB] $@
 	@scripts/deb/makedeb.py $<
-	@echo [APT-FTPARCHIVE] $@
-	@cd ./SRPMS && apt-ftparchive sources . > Sources
+	@echo [UPDATEREPO] $@
+	@flock --timeout 30 ./SRPMS scripts/deb/updaterepo sources SRPMS
 
 %.deb:
 	@echo [COWBUILDER] $@
+	@mkdir -p logs
+	@touch RPMS/Packages	
 	@sudo cowbuilder --build \
 		--configfile pbuilder/pbuilderrc \
 		--buildresult RPMS $<
-	@echo [APT-FTPARCHIVE] $@
-	@cd ./RPMS && apt-ftparchive packages . > Packages
-
+	@echo [UPDATEREPO] $@
+	@flock --timeout 30 ./RPMS scripts/deb/updaterepo packages RPMS
 
 
 # Dependency build rules
@@ -45,3 +46,4 @@ deps: SPECS/*.spec specdep.py scripts/lib/mappkgname.py
 	@./specdep.py -d $(DIST) -i libnl3 SPECS/*.spec > $@
 
 -include deps
+

--- a/scripts/deb/updaterepo
+++ b/scripts/deb/updaterepo
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Update the Debian repository metadata files.  
+# apt-ftparchive writes the new metadata to standard
+# output, which is then redirected to the appropriate
+# file.   This causes problems for concurrent builds
+# because the script takes time to print the new 
+# metadata, but the executing shell truncates the 
+# old metadata file immediately.  This means there
+# is a short period of time during which the metadata
+# file is empty, and if a concurrently-running build
+# tries to run apt during that period it will fail.
+#
+# To avoid this problem, we write the new metadata
+# file to a temporary file, then move that into the
+# correct place.
+#
+# Usage: updaterepo <sources|packages> <PKGDIR> 
+
+cd $2
+PID=$BASHPID
+
+case $1 in
+sources)
+        apt-ftparchive sources . > Sources.$PID
+	mv Sources.$PID Sources
+	;;
+packages)
+        apt-ftparchive packages . > Packages.$PID
+	mv Packages.$PID Packages
+	;;
+esac


### PR DESCRIPTION
Enable concurrent builds for RPMs and Debs.   Use make -j `<concurrency>` -l `<load limit>` to try it.   A good rule of thumb is to start with a concurrency value equal to the number of CPUs in the system.   Load limit should probably be a similar value to start with.  Don't use -l alone - when the builds start they don't do much, so the system will spawn many of them and then the load will skyrocket when they all start compiling at the same time!

Fixes issue #144 
