### PR TITLE
rpm/configure: Explicitly install createrepo

### DIFF
--- a/scripts/rpm/configure.sh
+++ b/scripts/rpm/configure.sh
@@ -3,7 +3,7 @@ set -eu
 
 echo "Configuring RPM-based build"
 
-rpm -q mock rpm-build >/dev/null 2>&1 || sudo yum install -y mock rpm-build
+rpm -q mock rpm-build createrepo >/dev/null 2>&1 || sudo yum install -y mock rpm-build createrepo
 
 echo -n "Writing mock configuration..."
 mkdir -p mock


### PR DESCRIPTION
Installing mock on CentOS 6.5 pulls in createrepo_c.  Install
the old createrepo explicitly so we can still use it.

Signed-off-by: Euan Harris euan.harris@citrix.com
