### PR TITLE
downloader: Update access time for existing archives

### DIFF
--- a/scripts/downloader.py
+++ b/scripts/downloader.py
@@ -44,6 +44,11 @@ def look_for_it(url, destination):
 		if os.path.exists(destination):
 			if looks_like_an_archive(destination):
 				print >>sys.stderr, "%s exists and looks like an archive" % destination
+				# Refresh the archive's last access time.
+				# If the spec file which depends on this archive has been modified, it will have a later access time than the archive and make will continually rebuild it.   'Touch' the archive, to prevent this happening
+				# There is a potential race here:  http://stackoverflow.com/questions/1158076/implement-touch-using-python
+				with open(destination, 'a'):
+					os.utime(destination, None)
 				return
 			else:
 				print >>sys.stderr, "%s is not an archive, deleting it" % destination


### PR DESCRIPTION
If a spec file is updated, make will call the downloader script to get
the source archives mentioned in the spec file.   If the source file
name has not changed and the file already exists, we need to update
its access time otherwise the spec file will always be newer than the
archives.   Otherwise make will always consider the source archives
to be out of date and will run the downloader to refresh them.

Signed-off-by: Euan Harris euan.harris@citrix.com
