### PR TITLE
Fix parallel make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,29 +4,44 @@ DIST := .el6
 
 all: rpms
 
+clean:
+	[ ! -e srpm_output.log ] || rm srpm_output.log
+	[ ! -e rpm_output.log ] || rm rpm_output.log
+	[ ! -e deps ] || rm deps
+	rm -rf RPMS SRPMS
+
+SRPMS/.stamp:
+	mkdir -p SRPMS
+	createrepo --quiet SRPMS
+	touch $@
+
+RPMS/.stamp:
+	mkdir -p RPMS
+	createrepo --quiet RPMS
+	touch $@
 
 # RPM build rules
 
-%.src.rpm: 
+%.src.rpm: SRPMS/.stamp
 	@echo [RPMBUILD] $@
-	@rpmbuild --quiet --define "_topdir ." --define "%dist $(DIST)" -bs $<
+	@rpmbuild --define "_topdir ." --define "%dist $(DIST)" -bs $(word 2,$^) >> srpm_output.log 2>&1
 	@echo [CREATEREPO] $@
-	@flock --timeout 30 ./SRPMS createrepo --quiet --update ./SRPMS
+	@scripts/runonce_queue.sh SRPMS 30 $@ createrepo --update ./SRPMS >> srpm_output.log 2>&1
 
-%.rpm:
+%.rpm: RPMS/.stamp
 	@echo [MOCK] $@
-	@mock --configdir=mock --quiet -r xenserver --resultdir=$(dir $@) --uniqueext=$(notdir $@) --rebuild $<
+	@mock --configdir=mock -r xenserver --resultdir=$(dir $@) --uniqueext=$(notdir $@) --rebuild $(word 2,$^) >> rpm_output.log 2>&1
 	@echo [CREATEREPO] $@
-	@flock --timeout 30 ./RPMS createrepo --quiet --update ./RPMS
+	@scripts/runonce_queue.sh RPMS 30 $@ createrepo --update ./RPMS >> rpm_output.log 2>&1
 
 
 # Deb build rules
 
 %.dsc: 
 	@echo [MAKEDEB] $@
-	@scripts/deb/makedeb.py $<
+	@scripts/deb/makedeb.py $< >> srpm_output.log 2>&1
 	@echo [UPDATEREPO] $@
-	@flock --timeout 30 ./SRPMS scripts/deb/updaterepo sources SRPMS
+	@scripts/runonce_queue.sh SRPMS 30 $@ scripts/deb/updaterepo sources SRPMS >> srpm_output.log 2>&1
 
 %.deb:
 	@echo [COWBUILDER] $@
@@ -34,9 +49,9 @@ all: rpms
 	@touch RPMS/Packages	
 	@sudo cowbuilder --build \
 		--configfile pbuilder/pbuilderrc \
-		--buildresult RPMS $<
+		--buildresult RPMS $< >> rpm_output.log 2>&1
 	@echo [UPDATEREPO] $@
-	@flock --timeout 30 ./RPMS scripts/deb/updaterepo packages RPMS
+	@scripts/runonce_queue.sh RPMS 30 $@ scripts/deb/updaterepo packages RPMS >> rpm_output.log 2>&1
 
 
 # Dependency build rules

--- a/scripts/rpm/configure.sh
+++ b/scripts/rpm/configure.sh
@@ -13,10 +13,3 @@ ln -fs /etc/mock/default.cfg mock/
 ln -fs /etc/mock/site-defaults.cfg mock/
 ln -fs /etc/mock/logging.ini mock/
 echo " done"
-
-echo -n "Initializing repository..."
-mkdir -p RPMS SRPMS
-createrepo --quiet RPMS
-createrepo --quiet SRPMS
-echo " done"
-

--- a/scripts/runonce_queue.sh
+++ b/scripts/runonce_queue.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -eu
+
+# Ensures only one process can call 'command' at any time
+# Implements a FIFO queue so process starvation does not occur
+#
+# Use case is to run a command which processes everything
+# in the queue at once, so when a job runs it clears out the
+# queue to prevent multiple-processing
+# 
+# Syntax:
+# $0 <lock_name> <timeout> <unique_token> <command> [<arg> ...]
+#
+# NOTE: the script may wait for 2 x timeout as the first timeout
+# is waiting to become the head of the queue and the second
+# timeout is waiting for <lock_name> to be available
+
+# Consume args as we go so we can use $* to run later
+lockfile=.${1//\//_}
+shift
+timeout=$1
+shift
+token=${1//\//_}
+shift
+
+queue_lockfile=${lockfile}.queue
+
+flock -w 1 $queue_lockfile -c "echo $token >> $queue_lockfile"
+
+# Wait for either us to be the head of the queue, or the queue to be empty
+# (which can happen if someone else has run for us while we were waiting)
+timeout $timeout bash << EOT
+set -eux
+head=\$(flock -w 1 $queue_lockfile -c "head -n1 $queue_lockfile")
+while [ -s $queue_lockfile -a "\$head" != "$token" ]; do
+        sleep 1;
+        head=\$(flock -w 1 $queue_lockfile -c "head -n1 $queue_lockfile")
+
+        # Remove the head if it's not running
+        kill -0 \$head >/dev/null 2>&1 || flock -w 1 $queue_lockfile -c "sed -i '/^\$head\\\$/d' $queue_lockfile"
+done
+EOT
+
+# We only need to run this command once for all in the queue
+# Use the actual lock now, so it doesn't matter if we change the queue, no one else
+# will get in here.
+(
+# Use flock to protect this whole block of code; fd 9 is redirected to $lockfile at the end of the block
+# Use a custom exit code so it's clear where the failure occured
+flock -w $timeout 9 || exit 76
+
+# Make sure we're still at the head of the queue; a previous run_once lock might have run for us
+head=$(head -n1 $queue_lockfile)
+if [ "$head" == "$token" ]; then
+
+        # We're running for the whole queue here, so remove the queue
+	(
+	# Use flock to protect this whole block of code; fd 8 is redirected to $queue_lockfile at the end of the block
+	flock -w 1 8 || exit 74
+	mv -f $queue_lockfile ${queue_lockfile}.running
+	touch $queue_lockfile
+	) 8>$queue_lockfile
+
+	# Log (if we're logging) who we are running the jobs for, then actually run it
+	echo "Running jobs for:"
+	cat ${queue_lockfile}.running
+        $*
+fi
+) 9>$lockfile
+


### PR DESCRIPTION
Flock does not have queueing, so it's very possible (and is consistently seen in some environments) that multiple threads will cause a timeout of one of the threads, thus failing the build.

Further, the createrepos only needs to be run once to pull in all SRPMs or all RPMs.

This change creates a queue which will run createrepos a minimum number of times, blocking make until createrepos has been run for that particular (S)RPM.
