### PR TITLE
xenopsd: populate the search-path in the xenopsd.conf file

### DIFF
--- a/SOURCES/make-xsc-xenopsd.conf
+++ b/SOURCES/make-xsc-xenopsd.conf
@@ -6,7 +6,8 @@ for i in wheel root xapi xendev; do
 done
 
 cat <<EOT
-# Binaries on the PATH or XCP_PATH
+search-path=/usr/lib/xen-4.5/bin:/usr/lib/xen-4.4/bin:${LIBEXECDIR}:${SCRIPTSDIR}
+
 eliloader=eliloader
 pygrub=pygrub
 qemu-system-i386=qemu-system-i386

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -1,6 +1,6 @@
 Name:           xenopsd
 Version:        0.9.43
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Simple VM manager
 License:        LGPL
 URL:            https://github.com/xapi-project/xenopsd
@@ -191,6 +191,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Mon Aug 8 2014 David Scott <dave.scott@citrix.com> - 0.9.43-4
+- Add a search-path to the xenopsd.conf
+
 * Thu Sep 4 2014 Jon Ludlam <jonathan.ludlam@citrix.com> - 0.9.43-3
 - Remove xen-missing-headers dependency
 


### PR DESCRIPTION
Related to [xenserver/buildroot#519]: it helps find pygrub

Signed-off-by: David Scott dave.scott@citrix.com
