### PR TITLE
Use the talex5's stable 4.4 branch of xen rather than 4.5

### DIFF
--- a/scripts/deb/templates/pbuilderrc
+++ b/scripts/deb/templates/pbuilderrc
@@ -1,5 +1,5 @@
 MIRRORSITE="@MIRROR@"
-OTHERMIRROR="deb file:@PWD@/RPMS/ ./ |deb http://xenbits.xenproject.org/djs/linaro-xen-4-5-preview/ ./ |deb-src file:@PWD@/SRPMS/ ./\
+OTHERMIRROR="deb file:@PWD@/RPMS/ ./ |deb http://xenbits.xenproject.org/djs/linaro-xen-4-4-talex5/ ./ |deb-src file:@PWD@/SRPMS/ ./\
 @APT_REPOS@"
 BINDMOUNTS="@PWD@/RPMS @PWD@/SRPMS"
 HOOKDIR="@PWD@/pbuilder"


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
