### PR TITLE
Makefile: Don't build the srpms repository by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DIST := .el6
 
 .PHONY: all rpms srpms srpm_repo
 
-all: rpms srpm_repo
+all: rpms
 
 
 ############################################################################


### PR DESCRIPTION
Currently the Debian and RPM builds share the rpms
and srpms targets, and the srpms_repo rule tries to
run createrepo which is not appropriate and will fail
on Debian.

The srpms_repo target is a convenience, not needed for
building binary packages.   It will return after we
separate the targets used for building .debs and .rpms.

Signed-off-by: Euan Harris euan.harris@citrix.com
