### PR TITLE
'make install' should only build the packages needed to install

### DIFF
--- a/pkg.py
+++ b/pkg.py
@@ -154,6 +154,12 @@ class Spec(object):
 
         return sources
 
+    def requires(self):
+        """Return the set of packages needed to install this spec"""
+        requires = flatten([pkg.header['requires'] + [pkg.header['name']]
+                            for pkg in self.spec.packages])
+        return set(flatten([self.map_package_name(r) for r
+                            in requires]))
 
     # RPM build dependencies.   The 'requires' key for the *source* RPM is
     # actually the 'buildrequires' key from the spec

--- a/scripts/deb/install.sh
+++ b/scripts/deb/install.sh
@@ -21,5 +21,5 @@ install -m 0644 scripts/deb/xapi.list /etc/apt/sources.list.d/xapi.list
 
 # Install
 apt-get update
-apt-get install -y --force-yes xenserver-core
+apt-get install -y --force-yes "$@"
 

--- a/scripts/rpm/install.sh
+++ b/scripts/rpm/install.sh
@@ -18,4 +18,4 @@ install -m 0644 scripts/rpm/epel.repo /etc/yum.repos.d/epel.repo
 install -m 0644 scripts/rpm/RPM-GPG-KEY-EPEL-6 /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
 
 yum repolist
-yum install -y xenserver-core
+yum install -y "$@"

--- a/specdep.py
+++ b/specdep.py
@@ -85,7 +85,7 @@ def package_to_rpm_map(specs):
     provides_to_rpm = {}
     for spec in specs:
         for provided in spec.provides():
-            provides_to_rpm[provided] = spec.binary_package_paths()[0]
+            provides_to_rpm[provided] = (spec, spec.binary_package_paths()[0])
     return provides_to_rpm
 
 
@@ -94,8 +94,16 @@ def buildrequires_for_rpm(spec, provides_to_rpm):
     for buildreq in spec.buildrequires():
         # Some buildrequires come from the system repository
         if provides_to_rpm.has_key(buildreq):
-            buildreqrpm = provides_to_rpm[buildreq]
+            buildreqrpm = provides_to_rpm[buildreq][1]
             print "%s: %s" % (rpmpath, buildreqrpm)
+
+
+def requires_for_rpm(spec, provides_to_rpm):
+    for buildreq in spec.requires():
+        # Some requires come from the system repository
+        if provides_to_rpm.has_key(buildreq):
+            requires_spec = provides_to_rpm[buildreq][0]
+            print "%s-deps: %s %s-deps" % (spec.name(), requires_spec.name(), requires_spec.name())
 
 
 def parse_cmdline():
@@ -151,6 +159,7 @@ def main():
         download_rpm_sources(spec)
         build_rpm_from_srpm(spec)
         buildrequires_for_rpm(spec, provides_to_rpm)
+        requires_for_rpm(spec, provides_to_rpm)
         print ""
 
     # Generate targets to build all srpms and all rpms
@@ -167,8 +176,8 @@ def main():
     print ""
     print "srpms: " + " \\\n\t".join(all_srpms)
     print ""
-    print "install: all"
-    print "\t. scripts/%s/install.sh" % build_type()
+    print "install: xenserver-core xenserver-core-deps"
+    print "\t. scripts/%s/install.sh xenserver-core" % build_type()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Needed to add a -deps target to support this.
To ensure that the install script doesn't diverge in what it is installing, move
the definition of what it will install to the deps file along-side what it is making