### PR TITLE
Remove libvirt as a requirement

### DIFF
--- a/SPECS/xenserver-core.spec
+++ b/SPECS/xenserver-core.spec
@@ -10,14 +10,12 @@ Requires:       xapi
 Requires:       xapi-python-devel
 Requires:       xapi-xe
 Requires:       xe-create-templates
-Requires:       xenopsd-libvirt
 Requires:       xenopsd-simulator
 Requires:       xenopsd-xc
 Requires:       xenopsd-xenlight
 Requires:       xenops-cli
 Requires:       ffs
 Requires:       sm-cli
-Requires:       xapi-libvirt-storage
 Requires:       xcp-sm
 Requires:       xcp-networkd
 Requires:       xcp-rrdd


### PR DESCRIPTION
libvirt can't be installed on F21 (it mucks up the networking) and the xenopsd-libvirt packages don't work properly anyway.  Remove the requirement for now until they can be fixed.
