### PR TITLE
Makefile: Remove deps file if dependency generation fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,11 @@ srpm_repo: srpms
 # Generate dependency rules linking spec files to tarballs, source
 # packages and binary packages.   specdep.py generates rules suitable
 # for RPM or Debian builds depending on the host distribution.
+# If dependency generation fails, the deps file is deleted to avoid
+# problems with empty, incomplete or corrupt deps.   
 deps: SPECS/*.spec specdep.py scripts/lib/mappkgname.py
 	@echo Updating dependencies...
-	@./specdep.py -d $(DIST) --ignore-from ignore SPECS/*.spec > $@
+	@./specdep.py -d $(DIST) --ignore-from ignore SPECS/*.spec > $@ || rm -f $@
 
 -include deps
 


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
