### PR TITLE
jenkins: Add Jenkins Docker slave configuration files

### DIFF
--- a/jenkins/centos-65/Dockerfile
+++ b/jenkins/centos-65/Dockerfile
@@ -1,0 +1,40 @@
+FROM            centos:latest
+MAINTAINER      Euan Harris <euan.harris@citrix.com>
+
+# Update
+RUN     yum upgrade -y
+
+# Install Jenkins requirements
+RUN     yum -y install openssh-server
+RUN     mkdir /var/run/sshd
+RUN     yum -y install java-1.7.0-openjdk
+
+RUN useradd jenkins 
+RUN echo "jenkins:jenkins" |chpasswd
+
+# Install EPEL
+RUN curl -OL http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+RUN curl -OL http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
+RUN rpm -Uvh remi-release-6*.rpm epel-release-6*.rpm
+
+# Install bootstrap dependencies
+RUN yum install -y mock redhat-lsb-core rpm-build git augeas sudo
+
+# Mock won't run as root
+RUN usermod -G mock,wheel -a jenkins
+
+# Disable 'requiretty' so that build scripts can call sudo
+RUN augtool -s set /files/etc/sudoers/Defaults[*]/requiretty/negate ""
+
+# Add jenkins to sudoers.  It's faster to write this file in the docker
+# recipe than to add it with 'add' because a rebuild of the image has to
+# start at the earliest add - RUNs can be taken from the cache.
+
+RUN echo 'jenkins ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/builder
+RUN chown root.root /etc/sudoers.d/builder
+RUN chmod 440 /etc/sudoers.d/builder
+
+RUN service sshd start
+
+EXPOSE 22
+CMD    /usr/sbin/sshd -D

--- a/jenkins/create-images.sh
+++ b/jenkins/create-images.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker build --rm=true --force-rm=true --tag=jenkins-centos-6.5 centos-65
+docker build --rm=true --force-rm=true --tag=jenkins-ubuntu-14.04 ubuntu-1404
+docker build --rm=true --force-rm=true --tag=jenkins-debian-jessie debian-jessie
+

--- a/jenkins/debian-jessie/Dockerfile
+++ b/jenkins/debian-jessie/Dockerfile
@@ -1,0 +1,40 @@
+FROM            debian:jessie
+MAINTAINER      Euan Harris <euan.harris@citrix.com>
+
+# Update
+RUN     apt-get -y update
+RUN     apt-get -y dist-upgrade
+
+# Install Jenkins requirements
+RUN     apt-get -y install openssh-server
+RUN     mkdir /var/run/sshd
+RUN     service ssh start
+RUN     apt-get -y install default-jre-headless
+
+RUN     useradd jenkins
+RUN     echo "jenkins:jenkins" |chpasswd
+RUN     mkdir -p /home/jenkins
+RUN     chown jenkins:jenkins /home/jenkins
+
+# Install bootstrap dependencies
+RUN     apt-get -y install git augeas-tools sudo lsb-release
+
+# Disable 'requiretty' so that build scripts can call sudo
+RUN     augtool -s set /files/etc/sudoers/Defaults[*]/requiretty/negate ""
+
+RUN     apt-get -y --force-yes install ocaml-nox
+
+# Make apt assume -y (needed for ./configure.sh)
+RUN     echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-assume-yes
+RUN     echo 'APT::Get::force-yes "true";' >> /etc/apt/apt.conf.d/90-assume-yes
+
+# Add jenkins to sudoers.  It's faster to write this file in the docker
+# recipe than to add it with 'add' because a rebuild of the image has to
+# start at the earliest add - RUNs can be taken from the cache.
+
+RUN     echo 'jenkins ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/builder
+RUN     chown root.root /etc/sudoers.d/builder
+RUN     chmod 440 /etc/sudoers.d/builder
+
+EXPOSE  22
+CMD     /usr/sbin/sshd -D

--- a/jenkins/ubuntu-1404/Dockerfile
+++ b/jenkins/ubuntu-1404/Dockerfile
@@ -1,0 +1,40 @@
+FROM            ubuntu:14.04
+MAINTAINER      Euan Harris <euan.harris@citrix.com>
+
+# Update
+RUN     apt-get -y update
+RUN     apt-get -y dist-upgrade
+
+# Install Jenkins requirements
+RUN     apt-get -y install openssh-server
+RUN     mkdir /var/run/sshd
+RUN     service ssh start
+RUN     apt-get -y install default-jre-headless
+
+RUN     useradd jenkins
+RUN     echo "jenkins:jenkins" |chpasswd
+RUN     mkdir -p /home/jenkins
+RUN     chown jenkins:jenkins /home/jenkins
+
+# Install bootstrap dependencies
+RUN     apt-get -y install git augeas-tools sudo lsb-release
+
+# Disable 'requiretty' so that build scripts can call sudo
+RUN     augtool -s set /files/etc/sudoers/Defaults[*]/requiretty/negate ""
+
+RUN     apt-get -y --force-yes install ocaml-nox
+
+# Make apt assume -y (needed for ./configure.sh)
+RUN     echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90-assume-yes
+RUN     echo 'APT::Get::force-yes "true";' >> /etc/apt/apt.conf.d/90-assume-yes
+
+# Add jenkins to sudoers.  It's faster to write this file in the docker
+# recipe than to add it with 'add' because a rebuild of the image has to
+# start at the earliest add - RUNs can be taken from the cache.
+
+RUN     echo 'jenkins ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/builder
+RUN     chown root.root /etc/sudoers.d/builder
+RUN     chmod 440 /etc/sudoers.d/builder
+
+EXPOSE  22
+CMD     /usr/sbin/sshd -D


### PR DESCRIPTION
Scripts and configuration files to set up Docker images which can be
used as dynamically-created Jenkins build workers through the Jenkins
Docker plugin.

Signed-off-by: Euan Harris euan.harris@citrix.com
