### PR TITLE
jenkins: Add wrapper scripts to run Docker containers

### DIFF
--- a/jenkins/run-interactive.sh
+++ b/jenkins/run-interactive.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker run --privileged --publish-all --tty --interactive --rm $1 /bin/bash
+

--- a/jenkins/run-server
+++ b/jenkins/run-server
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ID=`docker run --privileged --publish-all --detach $1`
+PORT=`docker port $ID 22/tcp | awk -F : '{print $2}'`
+
+echo Container ID: $ID
+echo Connect with: ssh jenkins@localhost -p $PORT


### PR DESCRIPTION
- run-server.sh creates a container in detached mode, as used by Jenkins.
  For convenience it prints the new container's ID and the ssh command to
  log into it.
- run-interactive.sh creates a container in interactive mode, running bash.
  The container will be destroyed when the shell exits.

Signed-off-by: Euan Harris euan.harris@citrix.com
