### PR TITLE
xcp-sm: setting LVM metadata to read_only breaks system boot after mkini...

### DIFF
--- a/SPECS/xcp-sm.spec
+++ b/SPECS/xcp-sm.spec
@@ -57,7 +57,6 @@ sed -i 's/metadata_read_only =.*/metadata_read_only = 0/' /etc/lvm/master/lvm.co
 sed -i 's/archive = .*/archive = 0/' /etc/lvm/master/lvm.conf || exit $?
 sed -i 's/filter \= \[ \"a\/\.\*\/\" \]/filter = \[ \"r\|\/dev\/xvd\.\|\"\, \"r\|\/dev\/VG\_Xen\.\*\/\*\|\"\]/g' /etc/lvm/master/lvm.conf || exit $?
 cp /etc/lvm/master/lvm.conf /etc/lvm/lvm.conf || exit $?
-sed -i 's/metadata_read_only =.*/metadata_read_only = 1/' /etc/lvm/lvm.conf || exit $?
 # We try to be "update-alternatives" ready.
 # If a file exists and it is not a symlink we back it up
 if [ -e /etc/multipath.conf -a ! -h /etc/multipath.conf ]; then


### PR DESCRIPTION
...trd

What seems to happen is:

- dracut copies the lvm.conf into the initrd
- the initrd fails at runtime complaining that metadata is read_only

This only happens if the initrd is regenerated after running the xcp-sm %post
action. This will happen even if you install xcp-sm and a kernel in the same
transaction since the mkinitrd will be deferred to the end (at least some of
the time)

Fixes #595

Signed-off-by: David Scott <dave.scott@eu.citrix.com>