### PR TITLE
Fix sm

### DIFF
--- a/SOURCES/xcp-sm-path-fix.patch
+++ b/SOURCES/xcp-sm-path-fix.patch
@@ -1,52 +1,55 @@
-commit cf4d8d60d19a2eaea489846ddd71532216204b29
+commit d9d2225510b7d8e0c0aff39923ba05d744448a73
 Author: Bob Ball <bob.ball@citrix.com>
-Date:   Mon Aug 18 14:03:50 2014 +0100
+Date:   Wed Jan 7 09:58:16 2015 +0000
 
-    xcp-sm-path-fix
+    xcp-sm-path-fix.patch
 
 diff --git a/Makefile b/Makefile
-index 3abb659..faca79e 100755
+index 1422578..bb7cedd 100755
 --- a/Makefile
 +++ b/Makefile
-@@ -53,13 +53,19 @@ SM_LIBS += lcache
- SM_LIBS += resetvdis
+@@ -57,6 +57,7 @@ SM_LIBS += resetvdis
  SM_LIBS += B_util
+ SM_LIBS += wwid_conf
  SM_LIBS += trim_util
 +SM_LIBS += constants
- MPATH_CONF = multipath.conf
  
- CRON_JOBS += ringwatch
+ UDEV_RULES = 40-multipath
+ MPATH_DAEMON = sm-multipath
+@@ -66,7 +67,11 @@ CRON_JOBS += ringwatch
  
  SM_XML := XE_SR_ERRORCODES
  
 -SM_DEST := /opt/xensource/sm/
-+BLKTAP_ROOT_DEFAULT := /usr/
 +SM_DEST_DEFAULT := /opt/xensource/sm/
++BLKTAP_ROOT_DEFAULT := /usr/
 +INVENTORY_DEFAULT := /etc/xensource-inventory
 +
-+BLKTAP_ROOT := $(BLKTAP_ROOT_DEFAULT)
 +SM_DEST := $(SM_DEST_DEFAULT)
  DEBUG_DEST := /opt/xensource/debug/
  BIN_DEST := /opt/xensource/bin/
  MASTER_SCRIPT_DEST := /etc/xensource/master.d/
-@@ -67,13 +73,14 @@ PLUGIN_SCRIPT_DEST := /etc/xapi.d/plugins/
- LIBEXEC := /opt/xensource/libexec/
- CRON_DEST := /etc/cron.d/
+@@ -76,6 +81,8 @@ CRON_DEST := /etc/cron.d/
+ UDEV_RULES_DIR := /etc/udev/rules.d/
+ INIT_DIR := /etc/rc.d/init.d/
  MPATH_CONF_DIR := /etc/multipath.xenserver/
++BLKTAP_ROOT := $(BLKTAP_ROOT_DEFAULT)
 +INVENTORY := $(INVENTORY_DEFAULT)
  
  SM_STAGING := $(DESTDIR)
  SM_STAMP := $(MY_OBJ_DIR)/.staging_stamp
+@@ -84,8 +91,8 @@ SM_PY_FILES = $(foreach LIB, $(SM_LIBS), drivers/$(LIB).py) $(foreach DRIVER, $(
  
  .PHONY: build
+ build:
 -	make -C dcopy 
 -	make -C mpathroot
 +	make -C dcopy DESTDIR=$(SM_STAGING) DEBUGDIR=$(DEBUG_DEST)
 +	make -C mpathroot DESTDIR=$(SM_STAGING) SM_DEST=$(SM_DEST)
  
- .PHONY: install
- install: 
-@@ -121,13 +128,17 @@ install:
+ .PHONY: precommit
+ precommit: build
+@@ -166,13 +173,17 @@ install: precheck
  	mkdir -p $(SM_STAGING)$(LIBEXEC)
  	install -m 755 scripts/local-device-change $(SM_STAGING)$(LIBEXEC)
  	install -m 755 scripts/check-device-sharing $(SM_STAGING)$(LIBEXEC)
@@ -105,23 +108,23 @@ index a596685..f4acf10 100755
              except:
                  util.SMlog("RawHBA: something wrong with mpathcount")
 diff --git a/drivers/SR.py b/drivers/SR.py
-index 25f409f..24be56f 100755
+index 699524e..166045e 100755
 --- a/drivers/SR.py
 +++ b/drivers/SR.py
-@@ -24,10 +24,11 @@ import errno
- import xs_errors
+@@ -25,10 +25,11 @@ import xs_errors
  import XenAPI, xmlrpclib, util
  import copy, os
+ import traceback
 +import constants
  
  MOUNT_BASE = '/var/run/sr-mount'
  DEFAULT_TAP = 'vhd'
 -TAPDISK_UTIL = '/usr/sbin/td-util'
 +TAPDISK_UTIL = os.path.join(constants.BLKTAP_ROOT, 'sbin', 'td-util')
+ MASTER_LVM_CONF = '/etc/lvm/master'
  
  # LUN per VDI key for XenCenter
- LUNPERVDI = "LUNperVDI"
-@@ -451,7 +452,7 @@ class SR(object):
+@@ -453,7 +454,7 @@ class SR(object):
                  self.mpath = "false"
                  self.mpathhandle = "null"
                  
@@ -130,7 +133,7 @@ index 25f409f..24be56f 100755
                  raise
          except:
              self.mpath = "false"
-@@ -476,7 +477,7 @@ class SR(object):
+@@ -479,7 +480,7 @@ class SR(object):
              self.session.xenapi.SR.set_sm_config(self.sr_ref, sm_config)
  
              if self.mpath == "true" and len(SCSIid):
@@ -140,10 +143,10 @@ index 25f409f..24be56f 100755
          except:
              pass
 diff --git a/drivers/blktap2.py b/drivers/blktap2.py
-index 0322276..30bee57 100755
+index ad89589..d70f2c9 100755
 --- a/drivers/blktap2.py
 +++ b/drivers/blktap2.py
-@@ -133,8 +133,8 @@ def retried(**args): return RetryLoop(**args)
+@@ -134,8 +134,8 @@ def retried(**args): return RetryLoop(**args)
  
  class TapCtl(object):
      """Tapdisk IPC utility calls."""
@@ -202,6 +205,35 @@ index 0000000..1fa7fab
 +SM_DEST='/opt/xensource/sm/'
 +BLKTAP_ROOT='/usr/'
 +INVENTORY='/etc/xensource-inventory'
+diff --git a/drivers/enable-borehamwood b/drivers/enable-borehamwood
+index c0014ac..6b65f62 100755
+--- a/drivers/enable-borehamwood
++++ b/drivers/enable-borehamwood
+@@ -14,7 +14,7 @@
+ import os, sys
+ import subprocess
+ 
+-DIR="/opt/xensource/sm/"
++SM_DEST="/opt/xensource/sm/"
+ FILENAME="RawHBASR"
+ 
+ def usage():
+@@ -26,13 +26,13 @@ if __name__ == "__main__":
+         sys.exit(1)
+ 
+     try:
+-        os.chdir(DIR)
++        os.chdir(SM_DEST)
+         os.symlink(FILENAME + ".py", FILENAME)
+     except OSError, e:
+         print "Error: %s [errno=%s]" % (e.args)
+         sys.exit(1)
+ 
+-    print "%s%s symlink created" % (DIR,FILENAME)
++    print "%s%s symlink created" % (SM_DEST,FILENAME)
+ 
+     try:
+         ret = subprocess.call(["xe-toolstack-restart"])
 diff --git a/drivers/intellicache-clean b/drivers/intellicache-clean
 index 64764ac..3b38796 100644
 --- a/drivers/intellicache-clean
@@ -220,7 +252,7 @@ index 64764ac..3b38796 100644
  import cleanup
  
 diff --git a/drivers/lvhd-thin b/drivers/lvhd-thin
-index 1c28253..94d4e89 100755
+index 42d509d..6129645 100755
 --- a/drivers/lvhd-thin
 +++ b/drivers/lvhd-thin
 @@ -18,9 +18,11 @@
@@ -237,10 +269,10 @@ index 1c28253..94d4e89 100755
  import vhdutil
  import lvhdutil
 diff --git a/drivers/mpath_dmp.py b/drivers/mpath_dmp.py
-index 1198358..e0fede0 100755
+index c4cd834..ea4d1bf 100755
 --- a/drivers/mpath_dmp.py
 +++ b/drivers/mpath_dmp.py
-@@ -51,7 +51,7 @@ def _is_mpath_daemon_running():
+@@ -52,7 +52,7 @@ def _is_mpath_daemon_running():
      return (rc==0)
  
  def _is_mpp_daemon_running():
@@ -250,7 +282,7 @@ index 1198358..e0fede0 100755
      if os.path.exists(UMPD_PATH):
          return True
 diff --git a/drivers/mpathcount.py b/drivers/mpathcount.py
-index 251926f..74d956b 100755
+index 92e8dbd..62ab7c1 100755
 --- a/drivers/mpathcount.py
 +++ b/drivers/mpathcount.py
 @@ -23,6 +23,7 @@ import mpath_cli
@@ -259,7 +291,7 @@ index 251926f..74d956b 100755
  import glob
 +import constants
  
- supported = ['iscsi','lvmoiscsi','rawhba','lvmohba','netapp']
+ supported = ['iscsi','lvmoiscsi','rawhba','lvmohba', 'ocfsohba', 'ocfsoiscsi', 'netapp']
  
 @@ -87,7 +88,7 @@ def match_host_id(s):
      return regex.search(s, 0)
@@ -303,7 +335,7 @@ index 3732723..cfc2455 100755
  import lock
  from lvmcache import LVMCache
 diff --git a/drivers/srmetadata.py b/drivers/srmetadata.py
-index 9025906..2ce176a 100755
+index f7c56aa..2d61c7c 100755
 --- a/drivers/srmetadata.py
 +++ b/drivers/srmetadata.py
 @@ -21,7 +21,6 @@ import util
@@ -372,18 +404,9 @@ index 77f670a..e1b93a1 100755
  
  		    # Now update the cache with this updated path status
 diff --git a/drivers/util.py b/drivers/util.py
-index 9cb97e5..c99cc20 100755
+index 06f55a4..a0d44ae 100755
 --- a/drivers/util.py
 +++ b/drivers/util.py
-@@ -18,7 +18,7 @@
- # Miscellaneous utility functions
- #
- 
--import os, re, sys, popen2, subprocess, shutil, tempfile, commands, signal
-+import os, re, sys, subprocess, shutil, tempfile, commands, signal
- import time, datetime
- import errno, socket
- import xml.dom.minidom
 @@ -34,6 +34,7 @@ import exceptions
  import traceback
  import glob
@@ -392,7 +415,7 @@ index 9cb97e5..c99cc20 100755
  
  NO_LOGGING_STAMPFILE='/etc/xensource/no_sm_log'
  
-@@ -536,7 +537,7 @@ def match_rootdev(s):
+@@ -547,7 +548,7 @@ def match_rootdev(s):
      return regex.search(s, 0)
  
  def getrootdev():
@@ -401,7 +424,7 @@ index 9cb97e5..c99cc20 100755
      try:
          f = open(filename, 'r')
      except:
-@@ -575,7 +576,7 @@ def get_localAPI_session():
+@@ -586,7 +587,7 @@ def get_localAPI_session():
  
  def get_this_host():
      uuid = None
@@ -410,7 +433,7 @@ index 9cb97e5..c99cc20 100755
      for line in f.readlines():
          if line.startswith("INSTALLATION_UUID"):
              uuid = line.split("'")[1]
-@@ -584,7 +585,7 @@ def get_this_host():
+@@ -600,7 +601,7 @@ def is_master(session):
  
  # XXX: this function doesn't do what it claims to do
  def get_localhost_uuid(session):
@@ -419,7 +442,7 @@ index 9cb97e5..c99cc20 100755
      try:
          f = open(filename, 'r')
      except:
-@@ -1059,7 +1060,7 @@ def p_id_fork():
+@@ -1075,7 +1076,7 @@ def p_id_fork():
              print "Fork failed: %s (%d)" % (e.strerror,e.errno)
              sys.exit(-1)
          if (p_id == 0):
@@ -442,7 +465,7 @@ index f6c6587..a4c4dd7 100755
          checkAllVHD(sys.argv[1])
  
 diff --git a/drivers/vhdutil.py b/drivers/vhdutil.py
-index cd8a08f..3967f1d 100755
+index 94696f7..bfd08f8 100755
 --- a/drivers/vhdutil.py
 +++ b/drivers/vhdutil.py
 @@ -24,11 +24,12 @@ import util
@@ -469,14 +492,13 @@ index cd8a08f..3967f1d 100755
      util.SMlog(text)
      for line in text.split('\n'):
 diff --git a/drivers/vss_control b/drivers/vss_control
-index 4070b4b..5fb1c7d 100755
+index 98a71e2..58358c5 100755
 --- a/drivers/vss_control
 +++ b/drivers/vss_control
-@@ -16,11 +16,14 @@
- # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- #
- # A plugin which is called to enable/disable VSS based quiesced VSS snapshots for a particular VM.  
-+
+@@ -18,11 +18,13 @@
+ # A plugin which is called to enable/disable VSS based quiesced VSS snapshots
+ # for a particular VM.
+ 
 +SM_DEST='/opt/xensource/sm/'
 +
  import os
@@ -490,7 +512,7 @@ index 4070b4b..5fb1c7d 100755
  import xslib
  import time 
 diff --git a/drivers/xs_errors.py b/drivers/xs_errors.py
-index e1817a4..52cf816 100755
+index b7ad8e5..380dff8 100755
 --- a/drivers/xs_errors.py
 +++ b/drivers/xs_errors.py
 @@ -22,8 +22,9 @@ import os
@@ -501,7 +523,7 @@ index e1817a4..52cf816 100755
  
 -XML_DEFS = '/opt/xensource/sm/XE_SR_ERRORCODES.xml'
 +XML_DEFS = os.path.join(constants.SM_DEST, 'XE_SR_ERRORCODES.xml')
- class XenError(object):
+ class XenError(Exception):
      def __init__(self, key, opterr=None):
          # Check the XML definition file exists
 diff --git a/mpathroot/Makefile b/mpathroot/Makefile
@@ -552,10 +574,10 @@ index 3f87cd7..c008d5e 100644
 \ No newline at end of file
 +exit 4
 diff --git a/scripts/local-device-change b/scripts/local-device-change
-index 9207cf2..dcf5fde 100755
+index 9d5720f..6fa76a0 100755
 --- a/scripts/local-device-change
 +++ b/scripts/local-device-change
-@@ -24,8 +24,9 @@ DEVICE=$1 # foo
+@@ -25,8 +25,9 @@ DEVICE=$1 # foo
  /usr/bin/logger "local-device-change DEVICE=$DEVICE ACTION=$ACTION"
  
  CDROMMON="/opt/xensource/libexec/cdrommon"
@@ -611,7 +633,7 @@ index aab8ad8..1af352f 100644
  
  DEBUG_OUT = False
 diff --git a/snapwatchd/snapwatchd b/snapwatchd/snapwatchd
-index 6374deb..88741e0 100755
+index be166ec..c60d242 100755
 --- a/snapwatchd/snapwatchd
 +++ b/snapwatchd/snapwatchd
 @@ -17,19 +17,22 @@

--- a/SOURCES/xcp-sm-pylint-fix.patch
+++ b/SOURCES/xcp-sm-pylint-fix.patch
@@ -1,11 +1,11 @@
-commit 0692dd162b09434b0b269c3077046072b8b504a6
+commit 057e15bb39eea1de2e40967d8967477cf3c98e3e
 Author: Bob Ball <bob.ball@citrix.com>
-Date:   Mon Aug 18 13:54:44 2014 +0100
+Date:   Wed Jan 7 09:44:20 2015 +0000
 
-    pylint-fix
+    xcp-sm-pylint-fix.patch
 
 diff --git a/drivers/cleanup.py b/drivers/cleanup.py
-index 37209f5..8ebe9ab 100755
+index 31ccb50..66e9197 100755
 --- a/drivers/cleanup.py
 +++ b/drivers/cleanup.py
 @@ -115,7 +115,7 @@ class Util:
@@ -18,10 +18,10 @@ index 37209f5..8ebe9ab 100755
              Util.log("`%s`: %s" % (args, rc))
          if type(expectedRC) != type([]):
 diff --git a/drivers/util.py b/drivers/util.py
-index 59f9a50..9cb97e5 100755
+index caeca96..06f55a4 100755
 --- a/drivers/util.py
 +++ b/drivers/util.py
-@@ -1358,6 +1358,7 @@ class extractXVA:
+@@ -1418,6 +1418,7 @@ class extractXVA:
      #   returns filename, checksum content. Returns filename, '' in case  
      #   of checksum file missing. e.g. ova.xml
      def getTuple(self):
@@ -30,15 +30,15 @@ index 59f9a50..9cb97e5 100755
          ret_f_name = ''
          ret_base_f_name = ''
 diff --git a/tests/pylintrc b/tests/pylintrc
-index 1f4b6f5..1d62dc7 100644
+index 29649ce..eb370ef 100644
 --- a/tests/pylintrc
 +++ b/tests/pylintrc
-@@ -68,7 +68,7 @@ disable-msg=E1201,E1202
- # if pylint complains with F0401 module can not be imported (due to the
- # libs are not present on your system), you can temporarily disable the
- # error by postfixing F0401 tag to the end of the following line.
--disable=design,rpython,newstyle,R,C,W,E1201,E0710,E1101 
-+disable=design,rpython,newstyle,R,C,W,E1201,E0710,E1101,F0401
+@@ -40,7 +40,7 @@ load-plugins=
+ # append the F0401 code at the end of the "disable" config variable to temporarily
+ # disable it from complaining missing libraries and get some useful information
+ # from a partial run at least. 
+-disable=design,rpython,newstyle,R,C,W,I
++disable=design,rpython,newstyle,R,C,W,I,F0401
  #,F0401
  
- [REPORTS]
+ 

--- a/SPECS/blktap.spec
+++ b/SPECS/blktap.spec
@@ -1,6 +1,6 @@
 Summary: Enhanced version of tapdisk
 Name:    blktap
-Version: 0.9.3
+Version: 0.9.3.fe874d
 Release: 1%{?dist}
 License: LGPL+linking exception
 URL:  https://github.com/xapi-project/blktap
@@ -55,7 +55,7 @@ make install DESTDIR=%{buildroot}
 %{_libdir}/%{name}/sbin/*
 
 %changelog
-* Mon Dec 8 2014 Bob Ball <bob.ball@citrix.com> - 0.9.3-1
+* Mon Dec 8 2014 Bob Ball <bob.ball@citrix.com> - 0.9.3.fe874d-1
 - Update to Creedence branch without grantcopy
 - Using checkpoint off xs64bit branch until an official release is made
 

--- a/SPECS/xcp-sm.spec
+++ b/SPECS/xcp-sm.spec
@@ -2,7 +2,7 @@
 
 Summary: XCP storage managers
 Name:    xcp-sm
-Version: 0.9.9
+Version: 0.9.8.7b9e69
 Release: 1%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
@@ -314,7 +314,7 @@ Fiber Channel raw LUNs as separate VDIs (LUN per VDI)
 %{_libdir}/xapi/sm/enable-borehamwood
 
 %changelog
-* Wed Jan 07 2015 Bob Ball <bob.ball@citrix.com> - 0.9.9-1
+* Wed Jan 07 2015 Bob Ball <bob.ball@citrix.com> - 0.9.8.7b9e69-1
 - Updated to master
 
 * Tue Sep 30 2014 Bob Ball <bob.ball@citrix.com> - 0.9.8-1

--- a/SPECS/xcp-sm.spec
+++ b/SPECS/xcp-sm.spec
@@ -2,11 +2,11 @@
 
 Summary: XCP storage managers
 Name:    xcp-sm
-Version: 0.9.8
+Version: 0.9.9
 Release: 1%{?dist}
 License: LGPL
 URL:  https://github.com/xapi-project/sm
-Source0: https://github.com/xapi-project/sm/archive/creedence-alpha-4/sm-%{version}.tar.gz
+Source0: https://github.com/xapi-project/sm/archive/7b9e693d3759f053869d641cc10cc0ed4234bbcc/sm-%{version}.tar.gz
 Source1: xcp-mpath-scsidev-rules
 Source2: xcp-mpath-scsidev-script
 Patch0: xcp-sm-scsi-id-path.patch
@@ -27,7 +27,7 @@ Requires: blktap
 This package contains storage backends used in XCP
 
 %prep
-%setup -q -n sm-creedence-alpha-4
+%setup -q -n sm-7b9e693d3759f053869d641cc10cc0ed4234bbcc
 %patch0 -p1
 %patch1 -p1
 %patch2 -p1
@@ -79,7 +79,9 @@ cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
 %files
 /etc/cron.d/*
 /etc/rc.d/init.d/snapwatchd
+/etc/rc.d/init.d/sm-multipath
 /etc/rc.d/init.d/mpathroot
+/etc/udev/rules.d/40-multipath.rules
 /etc/udev/rules.d/55-xs-mpath-scsidev.rules
 /etc/udev/scripts/xs-mpath-scsidev.sh
 %{_libdir}/xapi/plugins/coalesce-leaf
@@ -141,6 +143,17 @@ cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
 %{_libdir}/xapi/sm/NFSSR.py
 %{_libdir}/xapi/sm/NFSSR.pyc
 %{_libdir}/xapi/sm/NFSSR.pyo
+%{_libdir}/xapi/sm/OCFSSR.py
+%{_libdir}/xapi/sm/OCFSSR.pyc
+%{_libdir}/xapi/sm/OCFSSR.pyo
+%{_libdir}/xapi/sm/OCFSoHBASR
+%{_libdir}/xapi/sm/OCFSoHBASR.py
+%{_libdir}/xapi/sm/OCFSoHBASR.pyc
+%{_libdir}/xapi/sm/OCFSoHBASR.pyo
+%{_libdir}/xapi/sm/OCFSoISCSISR
+%{_libdir}/xapi/sm/OCFSoISCSISR.py
+%{_libdir}/xapi/sm/OCFSoISCSISR.pyc
+%{_libdir}/xapi/sm/OCFSoISCSISR.pyo
 %{_libdir}/xapi/sm/SHMSR.py
 %{_libdir}/xapi/sm/SHMSR.pyc
 %{_libdir}/xapi/sm/SHMSR.pyo
@@ -271,6 +284,9 @@ cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
 %{_libdir}/xapi/sm/trim_util.pyc
 %{_libdir}/xapi/sm/trim_util.pyo
 %{_libdir}/xapi/sm/vss_control
+%{_libdir}/xapi/sm/wwid_conf.py
+%{_libdir}/xapi/sm/wwid_conf.pyc
+%{_libdir}/xapi/sm/wwid_conf.pyo
 %{_libdir}/xapi/sm/xs_errors.py
 %{_libdir}/xapi/sm/xs_errors.pyc
 %{_libdir}/xapi/sm/xs_errors.pyo
@@ -298,6 +314,9 @@ Fiber Channel raw LUNs as separate VDIs (LUN per VDI)
 %{_libdir}/xapi/sm/enable-borehamwood
 
 %changelog
+* Wed Jan 07 2015 Bob Ball <bob.ball@citrix.com> - 0.9.9-1
+- Updated to master
+
 * Tue Sep 30 2014 Bob Ball <bob.ball@citrix.com> - 0.9.8-1
 - Moved patches to spec file rather than custom repository
 


### PR DESCRIPTION
We're currently waiting for formal tags to be used, but SM is breaking buildroot at the moment, and it's also using SHA1s.

This patch fixes buildroot in advance of the releases from storage.