### PR TITLE
ocaml-odn: Fix %{?_isa} annotation on devel package BuildRequires line

### DIFF
--- a/SPECS/ocaml-odn.spec
+++ b/SPECS/ocaml-odn.spec
@@ -22,7 +22,7 @@ like OASIS.
 %package        devel
 Summary:        Development files for %{name}
 Requires:       %{name} = %{version}-%{release}
-BuildRequires:	ocaml-type-conv%{_isa} >= 108.07.01
+BuildRequires:	ocaml-type-conv%{?_isa} >= 108.07.01
 
 %description    devel
 The %{name}-devel package contains libraries and signature files for


### PR DESCRIPTION
Signed-off-by: Euan Harris <euan.harris@citrix.com>