### PR TITLE
ocaml-ocplib-endian: Drop back to v0.5, avoiding bytes dependency

### DIFF
--- a/SPECS/ocaml-ocplib-endian.spec
+++ b/SPECS/ocaml-ocplib-endian.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ocaml-ocplib-endian
-Version:        0.8
+Version:        0.5
 Release:        1%{?dist}
 Summary:        Optimized functions to read and write int16/32/64 from strings and bigarrays
 License:        LGPL
@@ -63,7 +63,7 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/ocplib-endian/*.mli
 
 %changelog
-* Fri Jan 30 2015 Euan Harris <euan.harris@citrix.com> - 0.8-1
+* Fri Jan 30 2015 Euan Harris <euan.harris@citrix.com> - 0.5-1
 - Update to 0.8
 
 * Fri May 30 2014 Euan Harris <euan.harris@citrix.com> - 0.4-2


### PR DESCRIPTION
Signed-off-by: Euan Harris <euan.harris@citrix.com>