### PR TITLE
mock: Disable ccache plugin

### DIFF
--- a/scripts/rpm/mock-default.cfg.in
+++ b/scripts/rpm/mock-default.cfg.in
@@ -7,6 +7,7 @@ config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 
 config_opts['plugin_conf']['package_state_enable'] = False
 config_opts['plugin_conf']['tmpfs_enable'] = True    
+config_opts['plugin_conf']['ccache_enable'] = False
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
The ccache plugin seems to be causing build failures.
Disabling for now.

Signed-off-by: Euan Harris <euan.harris@citrix.com>